### PR TITLE
MPLUGIN-244  Help mojo generates Javadoc, which is not accepted by JDK 8...

### DIFF
--- a/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
+++ b/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Display help information on ${artifactId}.<br/>
+ * Display help information on ${artifactId}.<br>
  * Call <code>mvn ${goalPrefix}:help -Ddetail=true -Dgoal=&lt;goal-name&gt;</code> to display parameter details.
  * @author
  * @version


### PR DESCRIPTION
The <br/> close tag is causing Java 8 doclint to fail.

Stackoverflow http://stackoverflow.com/questions/13720626/is-javadoc-html-or-xhtml article suggests JavaDoc must be in html as opposed to xhtml.