### PR TITLE
Preserving the annotations at runtime is very useful for testing 

### DIFF
--- a/maven-plugin-annotations/pom.xml
+++ b/maven-plugin-annotations/pom.xml
@@ -37,5 +37,11 @@
       <artifactId>maven-artifact</artifactId>
       <version>3.0</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/Component.java
+++ b/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/Component.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * @since 3.0
  */
 @Documented
-@Retention( RetentionPolicy.CLASS )
+@Retention( RetentionPolicy.RUNTIME )
 @Target( { ElementType.FIELD } )
 @Inherited
 public @interface Component

--- a/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/Parameter.java
+++ b/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/Parameter.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * @since 3.0
  */
 @Documented
-@Retention( RetentionPolicy.CLASS )
+@Retention( RetentionPolicy.RUNTIME )
 @Target( { ElementType.FIELD } )
 @Inherited
 public @interface Parameter

--- a/maven-plugin-annotations/src/test/java/org/apache/maven/plugins/annotations/RuntimeAnnotationsTest.java
+++ b/maven-plugin-annotations/src/test/java/org/apache/maven/plugins/annotations/RuntimeAnnotationsTest.java
@@ -1,0 +1,45 @@
+package org.apache.maven.plugins.annotations;
+
+import java.lang.reflect.Field;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class RuntimeAnnotationsTest {
+
+  @Rule
+  public TestName name = new TestName();
+
+  @Parameter
+  private String parameter;
+
+
+
+  @Test
+  public void parameter() {
+    Assert.assertTrue(field().isAnnotationPresent(Parameter.class));
+  }
+
+  @Component
+  private Object component;
+
+  @Test
+  public void component() {
+    Assert.assertTrue(field().isAnnotationPresent(Component.class));
+  }
+
+
+  private Field field() {
+    try {
+      return getClass().getDeclaredField(name.getMethodName());
+    }
+    catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+    catch (SecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
I want to run a mojo in a harness for testing that can manage a variety of configurations, but relies on the annotation metadata to identify configuration points. 

I can't think of a good reason for not having these preserved at runtime. Hopefully this submission is a no brainer.
