### PR TITLE
upgrade to ASM 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,12 +221,10 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm-commons</artifactId>
-        <version>5.0.2</version>
       </dependency>
 
       <dependency>
@@ -432,12 +430,12 @@
           <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>6.0_ALPHA</version>
+            <version>6.1.1</version>
           </dependency>
           <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>6.0_ALPHA</version>
+            <version>6.1.1</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
The ALPHA dependency causes problems to projects using Enforcer rules, see https://github.com/jenkinsci/jacoco-plugin/pull/92#issuecomment-349457441