### PR TITLE
MPLUGIN-328 ArrayIndexOutOfBoundsException: 48188

### DIFF
--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
@@ -142,7 +142,14 @@ public class DefaultMojoAnnotationsScanner
                 {
                     continue;
                 }
-                analyzeClassStream( mojoAnnotatedClasses, archiveStream, artifact, excludeMojo );
+                try
+                {
+                    analyzeClassStream( mojoAnnotatedClasses, archiveStream, artifact, excludeMojo );
+                }
+                catch ( ArrayIndexOutOfBoundsException e )
+                {
+                    getLogger().warn( "Error analyzing class " + zipEntryName );
+                }
             }
         }
         catch ( IllegalArgumentException e )


### PR DESCRIPTION
If a dependency contains a class that could not be read by the default mojo annotation scanner, Maven will fail. Especially classes compiled using AspectJ are affected. Please consider merging this pull request, as it just lets Maven print a warning and won't let it interrupt the build process.

Fixes https://issues.apache.org/jira/browse/MPLUGIN-328