### PR TITLE
Prefer try-with-resources for file error handling

### DIFF
--- a/maven-plugin-plugin/src/it/fix-maven-since-3.x/javasample-maven-plugin/src/main/java/test/MyMojo.java
+++ b/maven-plugin-plugin/src/it/fix-maven-since-3.x/javasample-maven-plugin/src/main/java/test/MyMojo.java
@@ -53,30 +53,14 @@ public class MyMojo
 
         File touch = new File( f, "touch.txt" );
 
-        FileWriter w = null;
-        try
+        try ( FileWriter w = new FileWriter( touch ) )
         {
-            w = new FileWriter( touch );
 
             w.write( "touch.txt" );
         }
         catch ( IOException e )
         {
             throw new MojoExecutionException( "Error creating file " + touch, e );
-        }
-        finally
-        {
-            if ( w != null )
-            {
-                try
-                {
-                    w.close();
-                }
-                catch ( IOException e )
-                {
-                    // ignore
-                }
-            }
         }
     }
 }

--- a/maven-plugin-plugin/src/it/mplugin-191/src/main/java/org/apache/maven/plugins/plugin/it/MyMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-191/src/main/java/org/apache/maven/plugins/plugin/it/MyMojo.java
@@ -52,30 +52,14 @@ public class MyMojo
 
         File touch = new File( f, "touch.txt" );
 
-        FileWriter w = null;
-        try
+        try ( FileWriter w = new FileWriter( touch ) )
         {
-            w = new FileWriter( touch );
 
             w.write( "touch.txt" );
         }
         catch ( IOException e )
         {
             throw new MojoExecutionException( "Error creating file " + touch, e );
-        }
-        finally
-        {
-            if ( w != null )
-            {
-                try
-                {
-                    w.close();
-                }
-                catch ( IOException e )
-                {
-                    // ignore
-                }
-            }
         }
     }
 }

--- a/maven-plugin-plugin/src/it/mplugin-223/src/main/java/org/apache/maven/plugins/plugin/it/MyMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-223/src/main/java/org/apache/maven/plugins/plugin/it/MyMojo.java
@@ -52,30 +52,14 @@ public class MyMojo
 
         File touch = new File( f, "touch.txt" );
 
-        FileWriter w = null;
-        try
+        try ( FileWriter w = new FileWriter( touch ) )
         {
-            w = new FileWriter( touch );
 
             w.write( "touch.txt" );
         }
         catch ( IOException e )
         {
             throw new MojoExecutionException( "Error creating file " + touch, e );
-        }
-        finally
-        {
-            if ( w != null )
-            {
-                try
-                {
-                    w.close();
-                }
-                catch ( IOException e )
-                {
-                    // ignore
-                }
-            }
         }
     }
 }

--- a/maven-plugin-plugin/src/it/plugin-info-jdk-default-version/src/main/java/org/apache/maven/plugins/issues/plugin/MyMojo.java
+++ b/maven-plugin-plugin/src/it/plugin-info-jdk-default-version/src/main/java/org/apache/maven/plugins/issues/plugin/MyMojo.java
@@ -52,30 +52,14 @@ public class MyMojo
 
         File touch = new File( f, "touch.txt" );
 
-        FileWriter w = null;
-        try
+        try ( FileWriter w = new FileWriter( touch ) )
         {
-            w = new FileWriter( touch );
 
             w.write( "touch.txt" );
         }
         catch ( IOException e )
         {
             throw new MojoExecutionException( "Error creating file " + touch, e );
-        }
-        finally
-        {
-            if ( w != null )
-            {
-                try
-                {
-                    w.close();
-                }
-                catch ( IOException e )
-                {
-                    // ignore
-                }
-            }
         }
     }
 }

--- a/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
+++ b/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
@@ -114,10 +114,8 @@ public class HelpMojo
         throws MojoExecutionException
     {
         getLog().debug( "load plugin-help.xml: " + PLUGIN_HELP_PATH );
-        InputStream is = null;
-        try
+        try ( InputStream is = getClass().getResourceAsStream( PLUGIN_HELP_PATH ) )
         {
-            is = getClass().getResourceAsStream( PLUGIN_HELP_PATH );
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             return dBuilder.parse( is );
@@ -133,20 +131,6 @@ public class HelpMojo
         catch ( SAXException e )
         {
             throw new MojoExecutionException( e.getMessage(), e );
-        }
-        finally
-        {
-            if ( is != null )
-            {
-                try
-                {
-                    is.close();
-                }
-                catch ( IOException e )
-                {
-                    throw new MojoExecutionException( e.getMessage(), e );
-                }
-            }
         }
     }
 

--- a/maven-script/maven-script-ant/src/test/java/org/apache/maven/script/ant/AntMojoWrapperTest.java
+++ b/maven-script/maven-script-ant/src/test/java/org/apache/maven/script/ant/AntMojoWrapperTest.java
@@ -138,18 +138,10 @@ public class AntMojoWrapperTest
             fail( "plugin descriptor not found: '" + pluginXml + "'." );
         }
 
-        Reader reader = null;
         PluginDescriptor pd;
-        try
+        try ( Reader reader = new InputStreamReader( resource.openStream() ) )
         {
-            reader = new InputStreamReader( resource.openStream() );
             pd = new PluginDescriptorBuilder().build( reader, pluginXml );
-            reader.close();
-            reader = null;
-        }
-        finally
-        {
-            IOUtil.close( reader );
         }
 
         Map<String, Object> config = new HashMap<String, Object>();


### PR DESCRIPTION
Closing an `InputStream` in a finally block can mask exceptions thrown
in the `try` or `catch` blocks.  Found via error-prone.  Reference:

https://errorprone.info/bugpattern/Finally