### PR TITLE
[MPLUGIN-372] Descriptor mojo fails if super class is provided scope

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
@@ -262,12 +262,7 @@ public abstract class AbstractGeneratorMojo
         {
             throw new MojoExecutionException( "Error writing plugin descriptor", e );
         }
-        catch ( InvalidPluginDescriptorException e )
-        {
-            throw new MojoExecutionException( "Error extracting plugin descriptor: \'" + e.getLocalizedMessage() + "\'",
-                                              e );
-        }
-        catch ( ExtractionException e )
+        catch ( InvalidPluginDescriptorException | ExtractionException e )
         {
             throw new MojoExecutionException( "Error extracting plugin descriptor: \'" + e.getLocalizedMessage() + "\'",
                                               e );

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
@@ -127,14 +127,6 @@ public abstract class AbstractGeneratorMojo
     protected boolean skip;
 
     /**
-     * The set of dependencies for the current project
-     *
-     * @since 3.0
-     */
-    @Parameter( defaultValue = "${project.artifacts}", required = true, readonly = true )
-    protected Set<Artifact> dependencies;
-    
-    /**
      * Specify the dependencies as {@code groupId:artifactId} containing (abstract) Mojos, to filter
      * dependencies scanned at runtime and focus on dependencies that are really useful to Mojo analysis.
      * By default, the value is {@code null} and all dependencies are scanned (as before this parameter was added).
@@ -250,7 +242,7 @@ public abstract class AbstractGeneratorMojo
 
         try
         {
-            List<ComponentDependency> deps = GeneratorUtils.toComponentDependencies( project.getRuntimeDependencies() );
+            List<ComponentDependency> deps = GeneratorUtils.toComponentDependencies( project.getArtifacts() );
             pluginDescriptor.setDependencies( deps );
 
             PluginToolsRequest request = new DefaultPluginToolsRequest( project, pluginDescriptor );
@@ -313,7 +305,7 @@ public abstract class AbstractGeneratorMojo
         Set<Artifact> filteredDependencies;
         if ( mojoDependencies == null )
         {
-            filteredDependencies = dependencies;
+            filteredDependencies = new LinkedHashSet<>( project.getArtifacts() );
         }
         else if ( mojoDependencies.size() == 0 )
         {
@@ -325,7 +317,7 @@ public abstract class AbstractGeneratorMojo
             
             ArtifactFilter filter = new IncludesArtifactFilter( mojoDependencies );
 
-            for ( Artifact artifact : dependencies )
+            for ( Artifact artifact : project.getArtifacts() )
             {
                 if ( filter.include( artifact ) )
                 {

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
@@ -297,18 +297,18 @@ public abstract class AbstractGeneratorMojo
      */
     private Set<Artifact> filterMojoDependencies()
     {
-        Set<Artifact> filteredDependencies;
+        Set<Artifact> filteredArtifacts;
         if ( mojoDependencies == null )
         {
-            filteredDependencies = new LinkedHashSet<>( project.getArtifacts() );
+            filteredArtifacts = new LinkedHashSet<>( project.getArtifacts() );
         }
         else if ( mojoDependencies.size() == 0 )
         {
-            filteredDependencies = null;
+            filteredArtifacts = null;
         }
         else
         {
-            filteredDependencies = new LinkedHashSet<>();
+            filteredArtifacts = new LinkedHashSet<>();
             
             ArtifactFilter filter = new IncludesArtifactFilter( mojoDependencies );
 
@@ -316,11 +316,11 @@ public abstract class AbstractGeneratorMojo
             {
                 if ( filter.include( artifact ) )
                 {
-                    filteredDependencies.add( artifact );
+                    filteredArtifacts.add( artifact );
                 }
             }
         }
 
-        return filteredDependencies;
+        return filteredArtifacts;
     }
 }

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -43,7 +43,7 @@ import org.apache.maven.tools.plugin.generator.PluginDescriptorGenerator;
  * @since 2.0
  */
 @Mojo( name = "descriptor", defaultPhase = LifecyclePhase.PROCESS_CLASSES,
-       requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true )
+       requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true )
 public class DescriptorGeneratorMojo
     extends AbstractGeneratorMojo
 {

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
@@ -24,13 +24,12 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -174,14 +173,6 @@ public class PluginReport
     private boolean skipReport;
 
     /**
-     * The set of dependencies for the current project
-     *
-     * @since 3.0
-     */
-    @Parameter( defaultValue = "${project.artifacts}", required = true, readonly = true )
-    protected Set<Artifact> dependencies;
-
-    /**
      * List of Remote Repositories used by the resolver
      *
      * @since 3.0
@@ -316,13 +307,13 @@ public class PluginReport
 
         try
         {
-            List<ComponentDependency> deps = GeneratorUtils.toComponentDependencies( project.getRuntimeDependencies() );
+            List<ComponentDependency> deps = GeneratorUtils.toComponentDependencies( project.getArtifacts() );
             pluginDescriptor.setDependencies( deps );
 
             PluginToolsRequest request = new DefaultPluginToolsRequest( project, pluginDescriptor );
             request.setEncoding( encoding );
             request.setSkipErrorNoDescriptorsFound( true );
-            request.setDependencies( dependencies );
+            request.setDependencies( new LinkedHashSet<>( project.getArtifacts() ) );
             request.setLocal( this.local );
             request.setRemoteRepos( this.remoteRepos );
 

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
@@ -121,7 +121,7 @@ public final class GeneratorUtils
     }
     
     /**
-     * @param dependencies not null list of <code>Dependency</code>
+     * @param dependencies not null collection of <code>Artifact</code>
      * @return list of component dependencies
      */
     public static List<ComponentDependency> toComponentDependencies( Collection<Artifact> dependencies )

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
@@ -31,6 +31,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,8 +45,8 @@ import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.parser.ParserDelegator;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
@@ -123,11 +124,11 @@ public final class GeneratorUtils
      * @param dependencies not null list of <code>Dependency</code>
      * @return list of component dependencies
      */
-    public static List<ComponentDependency> toComponentDependencies( List<Dependency> dependencies )
+    public static List<ComponentDependency> toComponentDependencies( Collection<Artifact> dependencies )
     {
         List<ComponentDependency> componentDeps = new LinkedList<>();
 
-        for ( Dependency dependency : dependencies )
+        for ( Artifact dependency : dependencies )
         {
             ComponentDependency cd = new ComponentDependency();
 

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
@@ -121,21 +121,21 @@ public final class GeneratorUtils
     }
     
     /**
-     * @param dependencies not null collection of <code>Artifact</code>
+     * @param artifacts not null collection of <code>Artifact</code>
      * @return list of component dependencies
      */
-    public static List<ComponentDependency> toComponentDependencies( Collection<Artifact> dependencies )
+    public static List<ComponentDependency> toComponentDependencies( Collection<Artifact> artifacts )
     {
         List<ComponentDependency> componentDeps = new LinkedList<>();
 
-        for ( Artifact dependency : dependencies )
+        for ( Artifact artifact : artifacts )
         {
             ComponentDependency cd = new ComponentDependency();
 
-            cd.setArtifactId( dependency.getArtifactId() );
-            cd.setGroupId( dependency.getGroupId() );
-            cd.setVersion( dependency.getVersion() );
-            cd.setType( dependency.getType() );
+            cd.setArtifactId( artifact.getArtifactId() );
+            cd.setGroupId( artifact.getGroupId() );
+            cd.setVersion( artifact.getVersion() );
+            cd.setType( artifact.getType() );
 
             componentDeps.add( cd );
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MPLUGIN-372

Changes:
- Bug: adjust descriptor mojo resolution scope to include provided scope as well
- drop use of deprecated `project.getRuntimeDependencies()`
- Sanitized generator and report mojos (injects both project and project.artifacts, just one is completely enough)
- GeneratorUtils using Artifacts not Dependencies (as they were not needed)
- JavaAnnotationsMojoDescriptorExtractor error reporting: report failed class at least