### PR TITLE
[MPLUGIN-372] IT

### DIFF
--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/invoker.properties
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1 = install

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/invoker.properties
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/invoker.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals.1 = install
+invoker.goals = process-classes

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/pom.xml
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.annotation-with-inheritance-from-deps</groupId>
+  <artifactId>annotation-with-inheritance-from-deps</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Maven Integration Test :: annotation-with-inheritance-from-deps</name>
+  <description>
+    Test plugin-plugin, which tests maven-plugin-tools-api and 
+    maven-plugin-tools-java. This will generate a plugin descriptor from 
+    java-based mojo sources, install the plugin, and then use it.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <plexusCompilerVersion>1.8.6</plexusCompilerVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>@mavenVersion@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@project.version@</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-tools-annotations</artifactId>
+      <version>@project.version@</version>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <!-- dependency of  org.apache.maven.plugin-tools:maven-plugin-tools-annotations:@project.version@:jar:tests -->
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-compiler-manager</artifactId>
+      <version>${plexusCompilerVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-compiler-javac</artifactId>
+      <version>${plexusCompilerVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -1,0 +1,74 @@
+package org.apache.maven.plugin.coreit;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.tools.plugin.extractor.annotations.FooMojo;
+import org.apache.maven.project.MavenProjectHelper;
+
+/**
+ * Touches a test file.
+ *
+ * @since 1.2
+ */
+@Mojo( name = "first", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.INTEGRATION_TEST )
+public class FirstMojo
+    extends FooMojo
+{
+
+    /**
+     * @since 0.1
+     * @deprecated As of 0.2
+     */
+    @Parameter( alias = "alias" )
+    private String aliasedParam;
+
+    @Component( role = MavenProjectHelper.class )// , roleHint = "default"
+    private Object projectHelper;
+
+    public void execute()
+        throws MojoExecutionException
+    {
+        if ( bar == null )
+        {
+            throw new MojoExecutionException( "bar == null" );
+        }
+        if ( beer == null )
+        {
+            throw new MojoExecutionException( "beer == null" );
+        }
+        if ( projectHelper == null )
+        {
+            throw new MojoExecutionException( "projectHelper == null" );
+        }
+        if ( compilerManager == null )
+        {
+            throw new MojoExecutionException( "compilerManager == null" );
+        }
+
+    }
+
+}

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/resources/META-INF/maven/lifecycle.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<lifecycles>
+  <lifecycle>
+    <id>my-lifecycle</id>
+    <phases>
+      <phase>
+        <id>process-classes</id>
+      </phase>
+      <phase>
+        <id>test</id>
+        <configuration>
+          <classesDirectory>${project.build.directory}/generated-classes/cobertura</classesDirectory>
+          <testFailureIgnore>true</testFailureIgnore>
+        </configuration>
+      </phase>
+    </phases>
+  </lifecycle>
+</lifecycles>

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File descriptorFile = new File( basedir, "target/classes/META-INF/maven/plugin.xml" );
+assert descriptorFile.isFile()
+
+return true;

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/verify.groovy
@@ -19,5 +19,3 @@
 
 File descriptorFile = new File( basedir, "target/classes/META-INF/maven/plugin.xml" );
 assert descriptorFile.isFile()
-
-return true;


### PR DESCRIPTION
Adding separate IT that demonstrates how this IT FAILS (as expected)
on master, while passes with PR.

The IT itself is based on `annotation-with-inheritance-from-deps`
with following changes:
* dependency maven-plugin-api scope moved to `provided`
* FirstMojo got `@deprecated` javadoc tag REMOVED (to make maven-plugin-plugin search superclasses)

The IT against master shows that build FAILS (process-classes goal fail) as
maven-plugin-plugin:descriptor goal fails. It reports "API incompatible"
but actual cause is CNFEx.