### PR TITLE
Upgrade to maven 3.x and avoid using deprecated API

### DIFF
--- a/maven-plugin-plugin/pom.xml
+++ b/maven-plugin-plugin/pom.xml
@@ -49,10 +49,6 @@
       <artifactId>maven-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-tools-api</artifactId>
     </dependency>

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
@@ -46,11 +46,6 @@ under the License.
       <version>2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>@mavenVersion@</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>@project.version@</version>

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
@@ -31,11 +31,8 @@ import java.util.Map;
 import java.util.ResourceBundle;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.siterenderer.Renderer;
-import org.apache.maven.execution.RuntimeInformation;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.descriptor.InvalidPluginDescriptorException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -51,6 +48,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.AbstractMavenReportRenderer;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.rtinfo.RuntimeInformation;
 import org.apache.maven.tools.plugin.DefaultPluginToolsRequest;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
@@ -341,29 +339,22 @@ public class PluginReport
      * (because of Maven MNG-6109 bug that won't give accurate 'since' info when reading plugin.xml).
      * 
      * @return the proper pluginDescriptorBuilder
-     * @see https://issues.apache.org/jira/browse/MNG-6109
-     * @see https://issues.apache.org/jira/browse/MPLUGIN-319
+     * @see <a href="https://issues.apache.org/jira/browse/MNG-6109">MNG-6109</a>
+     * @see <a href="https://issues.apache.org/jira/browse/MPLUGIN-319">MPLUGIN-319</a>
      */
     private PluginDescriptorBuilder getPluginDescriptorBuilder()
     {
         PluginDescriptorBuilder pluginDescriptorBuilder;
-        try
+
+        if ( rtInfo.isMavenVersion( "(3.3.9,)" ) )
         {
-            VersionRange versionRange = VersionRange.createFromVersionSpec( "(3.3.9,)" );
-            if ( versionRange.containsVersion( rtInfo.getApplicationVersion() ) )
-            {
-                pluginDescriptorBuilder = new PluginDescriptorBuilder();
-            }
-            else
-            {
-                pluginDescriptorBuilder = new MNG6109PluginDescriptorBuilder();
-            }
+            pluginDescriptorBuilder = new PluginDescriptorBuilder();
         }
-        catch ( InvalidVersionSpecificationException e )
+        else
         {
-            return new MNG6109PluginDescriptorBuilder();
+            pluginDescriptorBuilder = new MNG6109PluginDescriptorBuilder();
         }
-        
+
         return pluginDescriptorBuilder;
     }
 

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugin.plugin.metadata;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
-import org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/GroupRepositoryMetadata.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/GroupRepositoryMetadata.java
@@ -1,0 +1,122 @@
+package org.apache.maven.plugin.plugin.metadata;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.metadata.AbstractRepositoryMetadata;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Plugin;
+
+/**
+ * Metadata for the group directory of the repository.
+ *
+ * @author <a href="mailto:brett@apache.org">Brett Porter</a>
+ */
+public class GroupRepositoryMetadata
+    extends AbstractRepositoryMetadata
+{
+    private final String groupId;
+
+    public GroupRepositoryMetadata( String groupId )
+    {
+        super( new Metadata() );
+        this.groupId = groupId;
+    }
+
+    public boolean storedInGroupDirectory()
+    {
+        return true;
+    }
+
+    public boolean storedInArtifactVersionDirectory()
+    {
+        return false;
+    }
+
+    public String getGroupId()
+    {
+        return groupId;
+    }
+
+    public String getArtifactId()
+    {
+        return null;
+    }
+
+    public String getBaseVersion()
+    {
+        return null;
+    }
+
+    public void addPluginMapping( String goalPrefix,
+                                  String artifactId )
+    {
+        addPluginMapping( goalPrefix, artifactId, artifactId );
+    }
+
+    public void addPluginMapping( String goalPrefix,
+                                  String artifactId,
+                                  String name )
+    {
+        List<Plugin> plugins = getMetadata().getPlugins();
+        boolean found = false;
+        for ( Iterator<Plugin> i = plugins.iterator(); i.hasNext() && !found; )
+        {
+            Plugin plugin = i.next();
+            if ( plugin.getPrefix().equals( goalPrefix ) )
+            {
+                found = true;
+            }
+        }
+        if ( !found )
+        {
+            Plugin plugin = new Plugin();
+            plugin.setPrefix( goalPrefix );
+            plugin.setArtifactId( artifactId );
+            plugin.setName( name );
+
+
+            getMetadata().addPlugin( plugin );
+        }
+    }
+
+    public Object getKey()
+    {
+        return groupId;
+    }
+
+    public boolean isSnapshot()
+    {
+        return false;
+    }
+
+    public ArtifactRepository getRepository()
+    {
+        return null;
+    }
+
+    public void setRepository( ArtifactRepository remoteRepository )
+    {
+        // intentionally blank
+    }
+}

--- a/maven-plugin-tools-annotations/pom.xml
+++ b/maven-plugin-tools-annotations/pom.xml
@@ -49,10 +49,6 @@
       <artifactId>maven-artifact</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-tools-api</artifactId>
     </dependency>

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorGenerator.java
@@ -179,6 +179,7 @@ public class PluginDescriptorGenerator
      * @param w              not null
      * @param helpDescriptor will clean html content from description fields
      */
+    @SuppressWarnings( "deprecation" )
     protected void processMojoDescriptor( MojoDescriptor mojoDescriptor, XMLWriter w, boolean helpDescriptor )
     {
         w.startElement( "mojo" );

--- a/maven-plugin-tools-generators/src/test/java/org/apache/maven/tools/plugin/generator/AbstractGeneratorTestCase.java
+++ b/maven-plugin-tools-generators/src/test/java/org/apache/maven/tools/plugin/generator/AbstractGeneratorTestCase.java
@@ -66,7 +66,7 @@ public abstract class AbstractGeneratorTestCase
         mojoDescriptor.setImplementation( "org.apache.maven.tools.plugin.generator.TestMojo" );
         mojoDescriptor.setDependencyResolutionRequired( "compile" );
 
-        List<Parameter> params = new ArrayList<Parameter>();
+        List<Parameter> params = new ArrayList<>();
 
         Parameter param = new Parameter();
         param.setExpression( "${project.build.directory}" );

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <surefire.version>2.22.2</surefire.version>
     <javaVersion>7</javaVersion>
     <pluginTestingHarnessVersion>1.3</pluginTestingHarnessVersion>
-    <mavenVersion>3.0</mavenVersion>
+    <mavenVersion>3.2.2</mavenVersion>
     <antVersion>1.7.1</antVersion>
     <mavenInvokerPluginVersion>3.2.2</mavenInvokerPluginVersion>
     <maven.site.path>plugin-tools-archives/plugin-tools-LATEST</maven.site.path>
@@ -152,11 +152,6 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-compat</artifactId>
         <version>${mavenVersion}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Upgrading to maven 3.2.x is necessary in order to get rid of the `org.apache.maven.execution.RuntimeInformation` which was deprecated in favor of `org.apache.maven.rtinfo.RuntimeInformation`.
The `org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata` class has been copied from `maven-compat`.