### PR TITLE
[MPLUGIN-370] Check that Maven dependencies are provided scope

### DIFF
--- a/maven-plugin-annotations/pom.xml
+++ b/maven-plugin-annotations/pom.xml
@@ -31,11 +31,4 @@
   <name>Maven Plugin Tools Java Annotations</name>
   <description>Java annotations to use in Mojos</description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>3.0</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/ResolutionScope.java
+++ b/maven-plugin-annotations/src/main/java/org/apache/maven/plugins/annotations/ResolutionScope.java
@@ -19,8 +19,6 @@ package org.apache.maven.plugins.annotations;
  * under the License.
  */
 
-import org.apache.maven.artifact.Artifact;
-
 /**
  * Dependencies resolution scopes available before
  * <a href="/ref/current/maven-core/apidocs/org/apache/maven/lifecycle/internal/MojoExecutor.html">mojo execution</a>.
@@ -38,28 +36,40 @@ public enum ResolutionScope
      * <code>compile</code> resolution scope
      * = <code>compile</code> + <code>system</code> + <code>provided</code> dependencies
      */
-    COMPILE( Artifact.SCOPE_COMPILE ),
+    COMPILE( ResolutionScope.SCOPE_COMPILE ),
     /**
      * <code>compile+runtime</code> resolution scope (Maven 3 only)
      * = <code>compile</code> + <code>system</code> + <code>provided</code> + <code>runtime</code> dependencies
      */
-    COMPILE_PLUS_RUNTIME( Artifact.SCOPE_COMPILE_PLUS_RUNTIME ),
+    COMPILE_PLUS_RUNTIME( ResolutionScope.SCOPE_COMPILE_PLUS_RUNTIME ),
     /**
      * <code>runtime</code> resolution scope
      * = <code>compile</code> + <code>runtime</code> dependencies
      */
-    RUNTIME( Artifact.SCOPE_RUNTIME ),
+    RUNTIME( ResolutionScope.SCOPE_RUNTIME ),
     /**
      * <code>runtime+system</code> resolution scope (Maven 3 only)
      * = <code>compile</code> + <code>system</code> + <code>runtime</code> dependencies
      */
-    RUNTIME_PLUS_SYSTEM( Artifact.SCOPE_RUNTIME_PLUS_SYSTEM ),
+    RUNTIME_PLUS_SYSTEM( ResolutionScope.SCOPE_RUNTIME_PLUS_SYSTEM ),
     /**
      * <code>test</code> resolution scope
      * = <code>compile</code> + <code>system</code> + <code>provided</code> + <code>runtime</code> + <code>test</code>
      * dependencies
      */
-    TEST( Artifact.SCOPE_TEST );
+    TEST( ResolutionScope.SCOPE_TEST );
+
+    // -- this block below MUST BE KEPT IN SYNC with org.apache.maven.artifact.Artifact constants!
+    private static final String SCOPE_COMPILE = "compile";
+
+    private static final String SCOPE_COMPILE_PLUS_RUNTIME = "compile+runtime";
+
+    private static final String SCOPE_TEST = "test";
+
+    private static final String SCOPE_RUNTIME = "runtime";
+
+    private static final String SCOPE_RUNTIME_PLUS_SYSTEM = "runtime+system";
+    // -- this block above MUST BE KEPT IN SYNC with org.apache.maven.artifact.Artifact constants!
 
     private final String id;
 

--- a/maven-plugin-plugin/pom.xml
+++ b/maven-plugin-plugin/pom.xml
@@ -47,10 +47,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/invoker.properties
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = process-classes

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/pom.xml
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.maven-deps-scope-bad</groupId>
+  <artifactId>maven-deps-scope-bad</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Maven Integration Test :: maven-deps-scope-bad</name>
+  <description>
+    Test plugin-plugin, which does not sets maven dependencies
+    to provided scope.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>@mavenVersion@</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@project.version@</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -1,0 +1,53 @@
+package org.apache.maven.plugin.coreit;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Touches a test file.
+ *
+ * @since 1.2
+ */
+@Mojo( name = "first", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.INTEGRATION_TEST )
+public class FirstMojo
+    extends AbstractMojo
+{
+
+    /**
+     * @since 0.1
+     * @deprecated As of 0.2
+     */
+    @Parameter( alias = "alias" )
+    private String aliasedParam;
+
+    public void execute()
+        throws MojoExecutionException
+    {
+        // nothing
+    }
+}

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/src/main/resources/META-INF/maven/lifecycle.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<lifecycles>
+  <lifecycle>
+    <id>my-lifecycle</id>
+    <phases>
+      <phase>
+        <id>process-classes</id>
+      </phase>
+      <phase>
+        <id>test</id>
+        <configuration>
+          <classesDirectory>${project.build.directory}/generated-classes/cobertura</classesDirectory>
+          <testFailureIgnore>true</testFailureIgnore>
+        </configuration>
+      </phase>
+    </phases>
+  </lifecycle>
+</lifecycles>

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File descriptorFile = new File( basedir, "build.log" );
+assert descriptorFile.isFile()
+assert descriptorFile.text.contains( "Maven dependencies of Maven Plugins should be in provided scope." )

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/invoker.properties
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = process-classes

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/pom.xml
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.maven-deps-scope-good</groupId>
+  <artifactId>maven-deps-scope-good</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Maven Integration Test :: maven-deps-scope-good</name>
+  <description>
+    Test plugin-plugin, which does sets maven dependencies
+    to provided scope.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>@mavenVersion@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@project.version@</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -1,0 +1,53 @@
+package org.apache.maven.plugin.coreit;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Touches a test file.
+ *
+ * @since 1.2
+ */
+@Mojo( name = "first", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.INTEGRATION_TEST )
+public class FirstMojo
+    extends AbstractMojo
+{
+
+    /**
+     * @since 0.1
+     * @deprecated As of 0.2
+     */
+    @Parameter( alias = "alias" )
+    private String aliasedParam;
+
+    public void execute()
+        throws MojoExecutionException
+    {
+        // nothing
+    }
+}

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/src/main/resources/META-INF/maven/lifecycle.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<lifecycles>
+  <lifecycle>
+    <id>my-lifecycle</id>
+    <phases>
+      <phase>
+        <id>process-classes</id>
+      </phase>
+      <phase>
+        <id>test</id>
+        <configuration>
+          <classesDirectory>${project.build.directory}/generated-classes/cobertura</classesDirectory>
+          <testFailureIgnore>true</testFailureIgnore>
+        </configuration>
+      </phase>
+    </phases>
+  </lifecycle>
+</lifecycles>

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File descriptorFile = new File( basedir, "build.log" );
+assert descriptorFile.isFile()
+assert !descriptorFile.text.contains( "Maven dependencies of Maven Plugins should be in provided scope." )

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
@@ -204,6 +204,22 @@ public abstract class AbstractGeneratorMojo
                                 + "In the future this error will break the build.\n\n" );
         }
 
+        Set<Artifact> wrongScopedArtifacts = mavenDependenciesNotInProvidedScope();
+        if ( !wrongScopedArtifacts.isEmpty() )
+        {
+            getLog().error( "\n\nMaven dependencies of Maven Plugins should be in provided scope.\n"
+                + "Please make sure that all your dependencies declared in POM having Group Id of\n"
+                + "org.apache.maven have set '<scope>provided</scope>' as well.\n"
+                + "In the future this error will break the build.\n\n"
+                + "Following dependencies are in wrong scope:\n"
+            );
+            for ( Artifact artifact : wrongScopedArtifacts )
+            {
+                getLog().error( artifact.toString() );
+            }
+            getLog().error( "\nPlease fix your build!\n" );
+        }
+
         String defaultGoalPrefix = getDefaultGoalPrefix( project );
           
         if ( goalPrefix == null )
@@ -292,6 +308,25 @@ public abstract class AbstractGeneratorMojo
             defaultGoalPrefix = PluginDescriptor.getGoalPrefixFromArtifactId( project.getArtifactId() );
         }
         return defaultGoalPrefix;
+    }
+
+    /**
+     * Collects all dependencies having {@code org.apache.maven} group Id that are NOT in provided scope.
+     */
+    private Set<Artifact> mavenDependenciesNotInProvidedScope()
+    {
+        LinkedHashSet<Artifact> wrongScopedDependencies = new LinkedHashSet<>();
+
+        for ( Artifact dependency : project.getArtifacts() )
+        {
+            if ( "org.apache.maven".equals( dependency.getGroupId() )
+                && !Artifact.SCOPE_PROVIDED.equals( dependency.getScope() ) )
+            {
+                wrongScopedDependencies.add( dependency );
+            }
+        }
+
+        return wrongScopedDependencies;
     }
 
     /**


### PR DESCRIPTION
This PR has two changes:
* removed maven-artifact from maven-plugin-annotations (to not pull in
  whole artifact just for 6 constants, thay may also cause havoc if
  plugin developer does NOT declare maven-artifact with proper version)
* generator mojo now yells if ANY of the core dependencies are not
  in proper scope.

https://issues.apache.org/jira/browse/MPLUGIN-370