### PR TITLE
Update ITs

### DIFF
--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/pom.xml
@@ -42,7 +42,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>@mavenVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>@mavenVersion@</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
@@ -43,7 +43,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>@mavenVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>@mavenVersion@</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
They used ancient maven API and expect things to be
on classpath, that is not the case anymore.

Changed fixed mvn version to param, and added maven-core
as dependency as the class is in maven-core.