### PR TITLE
Fix this logging as well

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/AbstractGeneratorMojo.java
@@ -237,8 +237,8 @@ public abstract class AbstractGeneratorMojo
         else if ( !goalPrefix.equals( defaultGoalPrefix ) )
         {
             getLog().warn(
-                "\n\nGoal prefix is specified as: '" + goalPrefix + "'. " + "Maven currently expects it to be '"
-                    + defaultGoalPrefix + "'.\n" );
+                LS + LS + "Goal prefix is specified as: '" + goalPrefix + "'. " + "Maven currently expects it to be '"
+                    + defaultGoalPrefix + "'." + LS );
         }
 
         mojoScanner.setActiveExtractors( extractors );


### PR DESCRIPTION
Commit 95f76d2b303c15de01bbb29e3d1a16db4595e44c missed
this one. Funnily, that commit got rid of use of
String.format and `%n`s, while here we have `\n`s.