### PR TITLE
[MPLUGIN-394] Respect input encoding

### DIFF
--- a/maven-plugin-plugin/src/it/mplugin-394_report-encoding/invoker.properties
+++ b/maven-plugin-plugin/src/it/mplugin-394_report-encoding/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = -Dfile.encoding=CP1252 plugin:report

--- a/maven-plugin-plugin/src/it/mplugin-394_report-encoding/pom.xml
+++ b/maven-plugin-plugin/src/it/mplugin-394_report-encoding/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.plugin</groupId>
+  <artifactId>report-encoding</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Maven Integration Test :: Report Encoding</name>
+  <description>
+    Tests correct usage of configured encoding for reports
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.report.outputEncoding>UTF-8</project.report.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>@mavenVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@project.version@</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin-plugin/src/it/mplugin-394_report-encoding/src/main/java/test/MyMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-394_report-encoding/src/main/java/test/MyMojo.java
@@ -1,0 +1,50 @@
+package test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Mojo-Description with some non-ASCII characters: €àáâãäåæòóôõöø
+ * <p>
+ * This file is encoded with UTF-8 and Maven is configured with UTF-8 for source
+ * files and UTF-8 as output encoding for the site.  Therefore we expect the
+ * generated site to contain all characters from above, even if the system
+ * encoding is not UTF-8.
+ */
+@Mojo( name= "test" )
+public class MyMojo
+    extends AbstractMojo
+{
+
+    /**
+     * Parameter-Description with some non-ASCII characters: ÈÉÊË€
+     */
+    @Parameter
+    private String testParam;
+
+
+    public void execute()
+    {
+    }
+
+}

--- a/maven-plugin-plugin/src/it/mplugin-394_report-encoding/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-394_report-encoding/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+generated = new File( basedir, "target/generated-site/xdoc/test-mojo.xml").getText("UTF-8")
+
+assert generated.contains("Mojo-Description with some non-ASCII characters: €àáâãäåæòóôõöø")
+assert generated.contains("Parameter-Description with some non-ASCII characters: ÈÉÊË€")
+
+return true;

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
@@ -20,8 +20,11 @@ package org.apache.maven.plugin.plugin;
  */
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -270,12 +273,13 @@ public class PluginReport
         throws MavenReportException
     {
         PluginDescriptorBuilder builder = getPluginDescriptorBuilder();
-        
-        try
+
+        final Charset charset = Charset.forName( getInputEncoding() );
+        try ( Reader input = new InputStreamReader( new FileInputStream( pluginXmlFile ), charset ) )
         {
-            return builder.build( new FileReader( pluginXmlFile ) );
+            return builder.build( input );
         }
-        catch ( FileNotFoundException | PlexusConfigurationException e )
+        catch ( IOException | PlexusConfigurationException e )
         {
             getLog().debug( "Failed to read " + pluginXmlFile + ", fall back to mojoScanner" );
         }

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/PluginReport.java
@@ -22,9 +22,7 @@ package org.apache.maven.plugin.plugin;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -63,6 +61,7 @@ import org.apache.maven.tools.plugin.util.PluginUtils;
 import org.codehaus.plexus.component.repository.ComponentDependency;
 import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
@@ -274,8 +273,7 @@ public class PluginReport
     {
         PluginDescriptorBuilder builder = getPluginDescriptorBuilder();
 
-        final Charset charset = Charset.forName( getInputEncoding() );
-        try ( Reader input = new InputStreamReader( new FileInputStream( pluginXmlFile ), charset ) )
+        try ( Reader input = new XmlStreamReader( new FileInputStream( pluginXmlFile ) ) )
         {
             return builder.build( input );
         }


### PR DESCRIPTION
PluginReport didn't specify an encoding while reading the
Plugin-Descriptor. This causes the fallback to the plattform encoding
and ignores the (user specified) input encoding.

This commits adds an integration test to reproduce the error and fixes
it by using the input encoding for the creation of the used Reader.

The integration tests forces the plattform encoding to CP1252 (Western
European charset used in Windows) while the source (input) and output
encoding is UTF-8.
The source file contains non-ASCII characters which have a different
representation in both encodings.