### PR TITLE
[MPLUGIN-399] Upgrade project dependencies after JDK 1.8

### DIFF
--- a/maven-plugin-tools-annotations/pom.xml
+++ b/maven-plugin-tools-annotations/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-        <version>4.2.5</version><!-- Java 7 -->
     </dependency>
         
     <dependency>
@@ -106,7 +105,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.9.1</version><!-- Java 7 -->
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-script/maven-script-ant/pom.xml
+++ b/maven-script/maven-script-ant/pom.xml
@@ -60,7 +60,6 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-        <version>4.2.5</version><!-- Java 7 -->
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <javaVersion>8</javaVersion>
     <pluginTestingHarnessVersion>3.3.0</pluginTestingHarnessVersion>
     <mavenVersion>3.2.5</mavenVersion>
-    <antVersion>1.9.16</antVersion>
+    <antVersion>1.10.12</antVersion>
     <maven.site.path>plugin-tools-archives/plugin-tools-LATEST</maven.site.path>
     <asmVersion>9.3</asmVersion>
     <project.build.outputTimestamp>2022-01-10T23:05:38Z</project.build.outputTimestamp>
@@ -183,7 +183,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
-        <version>3.6.0</version>
+        <version>4.2.7</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -225,10 +225,17 @@
         <version>${asmVersion}</version>
       </dependency>
 
+      <!-- testing -->
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>
         <artifactId>maven-plugin-testing-harness</artifactId>
         <version>${pluginTestingHarnessVersion}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.22.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
- plexus-archiver from 3.6.0 to 4.2.7
- assertj-core from 2.9.1 to 3.22.0
- antVersion from 1.9.16 to 1.10.12