### PR TITLE
[MPLUGIN-411] Get rid of plexus-compiler-manager from tests

### DIFF
--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/pom.xml
@@ -36,7 +36,6 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <plexusCompilerVersion>1.8.6</plexusCompilerVersion>
   </properties>
 
   <dependencies>
@@ -64,28 +63,6 @@ under the License.
       <version>4.13.2</version>
     </dependency>
     
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-manager</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -65,11 +65,6 @@ public class FirstMojo
         {
             throw new MojoExecutionException( "projectHelper == null" );
         }
-        if ( compilerManager == null )
-        {
-            throw new MojoExecutionException( "compilerManager == null" );
-        }
-
     }
 
 }

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/verify.groovy
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-from-deps/verify.groovy
@@ -54,15 +54,15 @@ assert mojo.configuration.beer[0].text() == '${thebeer}'
 assert mojo.configuration.beer[0].'@implementation' == 'java.lang.String'
 assert mojo.configuration.beer[0].'@default-value' == 'coolbeer'
 
-assert mojo.requirements.requirement.size() == 3
+assert mojo.requirements.requirement.size() == 2
 
-assert mojo.requirements.requirement[1].role.text() == 'org.codehaus.plexus.compiler.manager.CompilerManager'
+assert mojo.requirements.requirement[0].role.text() == 'org.apache.maven.artifact.metadata.ArtifactMetadataSource'
+assert mojo.requirements.requirement[0].'role-hint'.text() == 'maven'
+assert mojo.requirements.requirement[0].'field-name'.text() == 'artifactMetadataSource'
+
+assert mojo.requirements.requirement[1].role.text() == 'org.apache.maven.project.MavenProjectHelper'
 assert mojo.requirements.requirement[1].'role-hint'.text() == ''
-assert mojo.requirements.requirement[1].'field-name'.text() == 'compilerManager'
-
-assert mojo.requirements.requirement[2].role.text() == 'org.apache.maven.project.MavenProjectHelper'
-//assert mojo.requirements.requirement[2].'role-hint'.text() == 'default'
-assert mojo.requirements.requirement[2].'field-name'.text() == 'projectHelper'
+assert mojo.requirements.requirement[1].'field-name'.text() == 'projectHelper'
 
 assert mojo.parameters.parameter.size() == 3
 

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/module-abstract-mojo/src/main/java/org/apache/maven/plugins/AbstractFirstMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/module-abstract-mojo/src/main/java/org/apache/maven/plugins/AbstractFirstMojo.java
@@ -20,13 +20,8 @@ package org.apache.maven.plugins;
  */
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.compiler.manager.CompilerManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 
 import java.io.File;
@@ -48,12 +43,6 @@ public abstract class AbstractFirstMojo
     @Parameter( property = "first.touchFile", defaultValue = "${project.build.directory}/touch.txt",
                 required = true )
     protected File touchFile;
-
-    /**
-     * Plexus compiler manager.
-     */
-    @Component
-    protected CompilerManager compilerManager;
 
     /**
      *

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/module-mojo/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/module-mojo/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -66,10 +66,6 @@ public class FirstMojo
         {
             throw new MojoExecutionException( "projectHelper == null" );
         }
-        if ( compilerManager == null )
-        {
-            throw new MojoExecutionException( "compilerManager == null" );
-        }
         if (! ( projectHelper instanceof MavenProjectHelper ))
         {
             throw new MojoExecutionException( "! projectHelper instanceof MavenProjectHelper" );

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/pom.xml
@@ -35,7 +35,6 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <plexusCompilerVersion>1.8.6</plexusCompilerVersion>
   </properties>
 
   <dependencies>
@@ -66,28 +65,6 @@ under the License.
       <artifactId>maven-plugin-annotations</artifactId>
       <version>@project.version@</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-manager</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/verify.groovy
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance-reactor/verify.groovy
@@ -53,11 +53,11 @@ assert mojo.configuration.touchFile[0].text() == '${first.touchFile}'
 assert mojo.configuration.touchFile[0].'@implementation' == 'java.io.File'
 assert mojo.configuration.touchFile[0].'@default-value' == '${project.build.directory}/touch.txt'
 
-assert mojo.requirements.requirement.size() == 3
+assert mojo.requirements.requirement.size() == 2
 
-assert mojo.requirements.requirement[2].role.text() == 'org.apache.maven.project.MavenProjectHelper'
-//assert mojo.requirements.requirement[2].'role-hint'.text() == 'default'
-assert mojo.requirements.requirement[2].'field-name'.text() == 'projectHelper'
+assert mojo.requirements.requirement[1].role.text() == 'org.apache.maven.project.MavenProjectHelper'
+assert mojo.requirements.requirement[1].'role-hint'.text() == ''
+assert mojo.requirements.requirement[1].'field-name'.text() == 'projectHelper'
 
 assert mojo.parameters.parameter.size() == 3
 

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/pom.xml
@@ -36,7 +36,6 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <plexusCompilerVersion>1.8.6</plexusCompilerVersion>
   </properties>
 
   <dependencies>
@@ -55,28 +54,6 @@ under the License.
       <artifactId>maven-plugin-annotations</artifactId>
       <version>@project.version@</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-manager</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/AbstractFirstMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/AbstractFirstMojo.java
@@ -20,13 +20,8 @@ package org.apache.maven.plugin.coreit;
  */
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.compiler.manager.CompilerManager;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 
 import java.io.File;
@@ -47,12 +42,6 @@ public abstract class AbstractFirstMojo
     @Parameter( property = "first.touchFile", defaultValue = "${project.build.directory}/touch.txt",
                 required = true )
     protected File touchFile;
-
-    /**
-     * Plexus compiler manager.
-     */
-    @Component
-    protected CompilerManager compilerManager;
 
     /**
      *

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/AbstractFooMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/AbstractFooMojo.java
@@ -19,18 +19,6 @@ package org.apache.maven.plugin.coreit;
  * under the License.
  */
 
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.compiler.manager.CompilerManager;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
-
-import java.io.File;
-
 /**
  *
  */

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -72,10 +72,6 @@ public class FirstMojo
         {
             throw new MojoExecutionException( "projectHelper == null" );
         }
-        if ( compilerManager == null )
-        {
-            throw new MojoExecutionException( "compilerManager == null" );
-        }
 
         if ( dependencies.isEmpty() )
         {

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/ThirdMojo.java
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/src/main/java/org/apache/maven/plugin/coreit/ThirdMojo.java
@@ -72,11 +72,6 @@ public class ThirdMojo
         {
             throw new MojoExecutionException( "projectHelper == null" );
         }
-        if ( compilerManager == null )
-        {
-            throw new MojoExecutionException( "compilerManager == null" );
-        }
-
         if ( dependencies.isEmpty() )
         {
             throw new MojoExecutionException( "dependencies.isEmpty()" );

--- a/maven-plugin-plugin/src/it/annotation-with-inheritance/verify.groovy
+++ b/maven-plugin-plugin/src/it/annotation-with-inheritance/verify.groovy
@@ -57,11 +57,11 @@ assert mojo.configuration.touchFile[0].text() == '${first.touchFile}'
 assert mojo.configuration.touchFile[0].'@implementation' == 'java.io.File'
 assert mojo.configuration.touchFile[0].'@default-value' == '${project.build.directory}/touch.txt'
 
-assert mojo.requirements.requirement.size() == 3
+assert mojo.requirements.requirement.size() == 2
 
-assert mojo.requirements.requirement[2].role.text() == 'org.apache.maven.project.MavenProjectHelper'
+assert mojo.requirements.requirement[1].role.text() == 'org.apache.maven.project.MavenProjectHelper'
 //assert mojo.requirements.requirement[2].'role-hint'.text() == 'default'
-assert mojo.requirements.requirement[2].'field-name'.text() == 'projectHelper'
+assert mojo.requirements.requirement[1].'field-name'.text() == 'projectHelper'
 
 assert mojo.parameters.parameter.size() == 4
 

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/pom.xml
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/pom.xml
@@ -36,7 +36,6 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <plexusCompilerVersion>1.8.6</plexusCompilerVersion>
   </properties>
 
   <dependencies>
@@ -65,28 +64,6 @@ under the License.
       <version>4.13.2</version>
     </dependency>
     
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-manager</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexusCompilerVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>

--- a/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/mplugin-372-annotation-with-inheritance-from-provided-deps/src/main/java/org/apache/maven/plugin/coreit/FirstMojo.java
@@ -64,11 +64,6 @@ public class FirstMojo
         {
             throw new MojoExecutionException( "projectHelper == null" );
         }
-        if ( compilerManager == null )
-        {
-            throw new MojoExecutionException( "compilerManager == null" );
-        }
-
     }
 
 }

--- a/maven-plugin-tools-annotations/pom.xml
+++ b/maven-plugin-tools-annotations/pom.xml
@@ -87,12 +87,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-manager</artifactId>
-      <version>2.8.8</version><!-- Java 7 -->
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/FooMojo.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/FooMojo.java
@@ -27,7 +27,6 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.compiler.manager.CompilerManager;
 
 /**
  * @author Olivier Lamy
@@ -51,12 +50,6 @@ public class FooMojo
     @Deprecated
     @Parameter( property = "thebeer", defaultValue = "coolbeer" )
     protected String beer;
-
-    /**
-     * Plexus compiler manager.
-     */
-    @Component
-    protected CompilerManager compilerManager;
 
     /**
      *

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/TestAnnotationsReader.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/TestAnnotationsReader.java
@@ -79,7 +79,7 @@ public class TestAnnotationsReader
         assertEquals( LifecyclePhase.PACKAGE, execute.phase() );
 
         Collection<ComponentAnnotationContent> components = mojoAnnotatedClass.getComponents().values();
-        assertThat( components ).isNotNull().isNotEmpty().hasSize( 2 );
+        assertThat( components ).isNotNull().isNotEmpty().hasSize( 1 );
 
         Collection<ParameterAnnotationContent> parameters = mojoAnnotatedClass.getParameters().values();
         assertThat( parameters ).isNotNull().isNotEmpty().hasSize( 2 ).contains(


### PR DESCRIPTION
External dependency like plexus-compiler-manager no need to be used in tests.
The most of it tests used very old version of it.