### PR TITLE
[MPLUGIN-437] Fixes to the plugin descriptor generation

### DIFF
--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -540,21 +540,30 @@ public class JavaAnnotationsMojoDescriptorExtractor
                 return;
             }
 
-            // extract sources to target/maven-plugin-plugin-sources/${groupId}/${artifact}/sources
-            File extractDirectory = new File( request.getProject().getBuild().getDirectory(),
+            if ( sourcesArtifact.getFile().isFile() )
+            {
+                // extract sources to target/maven-plugin-plugin-sources/${groupId}/${artifact}/sources
+                File extractDirectory = new File( request.getProject().getBuild().getDirectory(),
                                               "maven-plugin-plugin-sources/" + sourcesArtifact.getGroupId() + "/"
                                                   + sourcesArtifact.getArtifactId() + "/" + sourcesArtifact.getVersion()
                                                   + "/" + sourcesArtifact.getClassifier() );
-            extractDirectory.mkdirs();
+                extractDirectory.mkdirs();
 
-            UnArchiver unArchiver = archiverManager.getUnArchiver( "jar" );
-            unArchiver.setSourceFile( sourcesArtifact.getFile() );
-            unArchiver.setDestDirectory( extractDirectory );
-            unArchiver.extract();
+                UnArchiver unArchiver = archiverManager.getUnArchiver( "jar" );
+                unArchiver.setSourceFile( sourcesArtifact.getFile() );
+                unArchiver.setDestDirectory( extractDirectory );
+                unArchiver.extract();
 
-            extendJavaProjectBuilder( builder,
-                                      Arrays.asList( extractDirectory ),
-                                      request.getDependencies() );
+                extendJavaProjectBuilder( builder,
+                                          Arrays.asList( extractDirectory ),
+                                          request.getDependencies() );
+            }
+            else if ( sourcesArtifact.getFile().isDirectory() )
+            {
+                extendJavaProjectBuilder( builder,
+                        Arrays.asList( sourcesArtifact.getFile() ),
+                        request.getDependencies() );
+            }
         }
         catch ( ArchiverException | NoSuchArchiverException e )
         {

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContext.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContext.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.builder.TypeAssembler;
 import com.thoughtworks.qdox.library.ClassNameLibrary;
-import com.thoughtworks.qdox.library.SourceLibrary;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaModule;
@@ -81,13 +80,6 @@ public class JavaClassConverterContext
                                       Map<String, MojoAnnotatedClass> mojoAnnotatedClasses,
                                       JavadocLinkGenerator linkGenerator, int lineNumber )
     {
-        if ( !( mojoClass.getJavaClassLibrary() instanceof SourceLibrary )
-            || !( declaringClass.getJavaClassLibrary() instanceof SourceLibrary ) )
-        {
-            throw new IllegalStateException( "The given javaClasses must be loaded by SourceLibrary to have access to"
-                + "e.g. the imports statements in it" );
-        }
-
         this.mojoClass = mojoClass;
         this.declaringClass = declaringClass;
         this.javaProjectBuilder = javaProjectBuilder;


### PR DESCRIPTION
When a mojo inherits from a mojo in a different project, the plugin descriptor generation fails.
Another problem is when the source artifact is being built in the same reactor, I had a case where the resolved artifacts file was pointing to a directory.