### PR TITLE
[MNG-7611] Change semantics of plugin descriptor's "requiredJavaVersion"

### DIFF
--- a/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
+++ b/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
@@ -25,7 +25,7 @@ assert descriptorFile.isFile()
 
 def pluginDescriptor = new XmlParser().parse( descriptorFile );
 
-assert pluginDescriptor.requiredJavaVersion.text() == '[1.8,)'
+assert pluginDescriptor.requiredJavaVersion.text() == '1.8'
 assert pluginDescriptor.requiredMavenVersion.text() == '3.2.5'
 
 def mojo = pluginDescriptor.mojos.mojo.findAll{ it.goal.text() == "first" }[0]

--- a/maven-plugin-plugin/src/it/v4api/verify.groovy
+++ b/maven-plugin-plugin/src/it/v4api/verify.groovy
@@ -22,7 +22,7 @@ assert descriptorFile.isFile()
 
 def pluginDescriptor = new XmlParser().parse( descriptorFile );
 
-assert pluginDescriptor.requiredJavaVersion.text() == '[1.8,)'
+assert pluginDescriptor.requiredJavaVersion.text() == '1.8'
 assert pluginDescriptor.requiredMavenVersion.text() == '4.0.0-alpha-2'
 
 def mojo = pluginDescriptor.mojos.mojo.findAll{ it.goal.text() == "first" }[0]

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -252,9 +252,9 @@ public class DescriptorGeneratorMojo
      * Maven versions. Can be either one of the following formats:
      * 
      * <ul>
-     * <li>One of the values as for <a href="https://maven.apache.org/pom.html#Activation">POM profile activation
-     * element {@code jdk}</a>, i.e. version ranges, version prefixes
-     * and negated version prefixes (starting with '!').</li>
+     * <li>A version range which specifies the supported Java versions. It can either use the usual mathematical
+     * syntax like {@code "[2.0.10,2.1.0),[3.0,)"} or use a single version like {@code "2.2.1"}. The latter is a short
+     * form for {@code "[2.2.1,)"}, i.e. denotes the minimum version required.</li>
      * <li>{@code "auto"} to determine the minimum Java version from the binary class version being generated during
      * compilation (determined by the extractor).</li>
      * </ul>
@@ -456,7 +456,7 @@ public class DescriptorGeneratorMojo
             return null;
         }
         
-        return "[" + minRequiredJavaVersion + ",)";
+        return minRequiredJavaVersion;
     }
 
     /**

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/PluginToolsRequest.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/PluginToolsRequest.java
@@ -200,7 +200,8 @@ public interface PluginToolsRequest
     
     /**
      * 
-     * @param requiredJavaVersion the minimally required java version for this plugin or {@code null} if unknown.
+     * @param requiredJavaVersion the required Java version for this plugin or {@code null} if unknown.
+     *  Must be a value according to semantics of {@link org.eclipse.aether.version.VersionConstraint}.
      * @return This request.
      * @since 3.8.0
      */
@@ -208,7 +209,8 @@ public interface PluginToolsRequest
 
     /**
      * 
-     * @return the minimally required java version for this plugin or {@code null} if unknown.
+     * @return the required Java version for this plugin or {@code null} if unknown.
+     *  Is a value according to semantics of {@link org.eclipse.aether.version.VersionConstraint}.
      * @since 3.8.0
      */
     String getRequiredJavaVersion();


### PR DESCRIPTION
Generate simple version constraints automatically
Fix Javadoc