### PR TITLE
[MPLUGIN-452] Maven scope and module name logs at wrong level

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -318,7 +318,7 @@ public class DescriptorGeneratorMojo
             Set<Artifact> wrongScopedArtifacts = dependenciesNotInProvidedScope();
             if ( !wrongScopedArtifacts.isEmpty() )
             {
-                StringBuilder errorMessage = new StringBuilder(
+                StringBuilder message = new StringBuilder(
                     LS + LS + "Some dependencies of Maven Plugins are expected to be in provided scope." + LS
                         + "Please make sure that dependencies listed below declared in POM" + LS
                         + "have set '<scope>provided</scope>' as well." + LS + LS
@@ -326,11 +326,11 @@ public class DescriptorGeneratorMojo
                 );
                 for ( Artifact artifact : wrongScopedArtifacts )
                 {
-                    errorMessage.append( " * " ).append( artifact ).append( LS );
+                    message.append( " * " ).append( artifact ).append( LS );
                 }
-                errorMessage.append( LS ).append( LS );
+                message.append( LS ).append( LS );
 
-                getLog().warn( errorMessage.toString() );
+                getLog().warn( message.toString() );
             }
         }
 

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -301,7 +301,7 @@ public class DescriptorGeneratorMojo
                         && project.getArtifactId().toLowerCase().endsWith( "-plugin" )
                         && !"org.apache.maven.plugins".equals( project.getGroupId() ) )
         {
-            getLog().error( LS + LS + "Artifact Ids of the format maven-___-plugin are reserved for" + LS
+            getLog().warn( LS + LS + "Artifact Ids of the format maven-___-plugin are reserved for" + LS
                                 + "plugins in the Group Id org.apache.maven.plugins" + LS
                                 + "Please change your artifactId to the format ___-maven-plugin" + LS
                                 + "In the future this error will break the build." + LS + LS );
@@ -330,7 +330,7 @@ public class DescriptorGeneratorMojo
                 }
                 errorMessage.append( LS ).append( LS );
 
-                getLog().error( errorMessage.toString() );
+                getLog().warn( errorMessage.toString() );
             }
         }
 


### PR DESCRIPTION
Should be logged at WARN level, and not ERROR level. When Mojo logs ERROR, it is expected that it fails the build. And this also confuses the Verifier.

---

https://issues.apache.org/jira/browse/MPLUGIN-452