### PR TITLE
Close br elements to properly be validated as XDoc

### DIFF
--- a/maven-plugin-tools-generators/src/main/resources/help-class-source-v4.vm
+++ b/maven-plugin-tools-generators/src/main/resources/help-class-source-v4.vm
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Display help information on ${artifactId}.<br>
+ * Display help information on ${artifactId}.<br/>
  * Call <code>mvn ${goalPrefix}:help -Ddetail=true -Dgoal=&lt;goal-name&gt;</code> to display parameter details.
  * @author maven-plugin-tools
  */

--- a/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
+++ b/maven-plugin-tools-generators/src/main/resources/help-class-source.vm
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Display help information on ${artifactId}.<br>
+ * Display help information on ${artifactId}.<br/>
  * Call <code>mvn ${goalPrefix}:help -Ddetail=true -Dgoal=&lt;goal-name&gt;</code> to display parameter details.
  * @author maven-plugin-tools
 #if ( !$useAnnotations )     


### PR DESCRIPTION
This allows correctly generating plugin reports.  
Otherwise, when configuring `maven-plugin-report-plugin`

```xml
<reporting>
  <plugins>
    <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-plugin-report-plugin</artifactId>
      <version>3.8.1</version>
      <configuration>
        <enhancedPluginXmlFile>${project.build.outputDirectory}/META-INF/maven/plugin.xml</enhancedPluginXmlFile>
      </configuration>
    </plugin>
  </plugins>
</reporting>
```

An error will be thrown out

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.1:site (default-site) on project plugin-resources: Error parsing 'C:\Users\edoardo.luppi\
maven-utils\plugins\plugin-resources\target\generated-site\xdoc\help-mojo.xml': line [12] Error parsing the model: end tag name </div> must match start tag name <br> fr
om line 11 (position: TEXT seen ...</code> to display parameter details.</div>... @12:112)  -> [Help 1]
```

![image](https://user-images.githubusercontent.com/19871649/224429124-ffac35dc-563a-4427-9425-812154581a0f.png)
