### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/report_old/PluginReport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/report_old/PluginReport.java
@@ -378,7 +378,7 @@ public class PluginReport extends AbstractMavenReport {
 
             this.project = project;
 
-            this.requirements = (requirements == null ? new Requirements() : requirements);
+            this.requirements = requirements == null ? new Requirements() : requirements;
 
             this.requirementsHistories = requirementsHistories;
 
@@ -496,7 +496,7 @@ public class PluginReport extends AbstractMavenReport {
             sink.tableRow_();
 
             String memory = requirements.getMemory();
-            if (StringUtils.isNotEmpty(memory)) {
+            if (memory != null && !memory.isEmpty()) {
                 sink.tableRow();
                 tableCell(getBundle(locale).getString("report.plugin.systemrequirements.memory"));
                 tableCell(memory);
@@ -504,7 +504,7 @@ public class PluginReport extends AbstractMavenReport {
             }
 
             String diskSpace = requirements.getDiskSpace();
-            if (StringUtils.isNotEmpty(diskSpace)) {
+            if (diskSpace != null && !diskSpace.isEmpty()) {
                 sink.tableRow();
                 tableCell(getBundle(locale).getString("report.plugin.systemrequirements.diskspace"));
                 tableCell(diskSpace);
@@ -668,9 +668,9 @@ public class PluginReport extends AbstractMavenReport {
         private static String discoverMavenRequirement(MavenProject project, Requirements requirements) {
             String maven = requirements.getMaven();
             if (maven == null) {
-                maven = (project.getPrerequisites() != null
+                maven = project.getPrerequisites() != null
                         ? project.getPrerequisites().getMaven()
-                        : null);
+                        : null;
             }
             if (maven == null) {
                 maven = "2.0";

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -756,7 +756,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
                                     + "forbidden characters ${}: " + property,
                             null);
                 }
-                parameter.setExpression(StringUtils.isEmpty(property) ? "" : "${" + property + "}");
+                parameter.setExpression((property == null || property.isEmpty()) ? "" : "${" + property + "}");
                 StringBuilder type = new StringBuilder(parameterAnnotationContent.getClassName());
                 if (!parameterAnnotationContent.getTypeParameters().isEmpty()) {
                     type.append(parameterAnnotationContent.getTypeParameters().stream()
@@ -818,7 +818,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             return mojoAnnotatedClass;
         }
         String parentClassName = mojoAnnotatedClass.getParentClassName();
-        if (StringUtils.isEmpty(parentClassName)) {
+        if (parentClassName == null || parentClassName.isEmpty()) {
             return null;
         }
         MojoAnnotatedClass parent = mojoAnnotatedClasses.get(parentClassName);

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/visitors/MojoClassVisitor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/visitors/MojoClassVisitor.java
@@ -153,7 +153,7 @@ public class MojoClassVisitor extends ClassVisitor {
      * @return the list of type parameters (may be empty)
      */
     private List<String> extractTypeParameters(int access, String signature, boolean isField) {
-        if (StringUtils.isEmpty(signature)) {
+        if (signature == null || signature.isEmpty()) {
             return Collections.emptyList();
         }
         TraceSignatureVisitor traceSignatureVisitor = new TraceSignatureVisitor(access);

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/DefaultPluginToolsRequest.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/DefaultPluginToolsRequest.java
@@ -28,7 +28,6 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystemSession;
 
 /**
@@ -119,7 +118,7 @@ public class DefaultPluginToolsRequest implements PluginToolsRequest {
      */
     @Override
     public PluginToolsRequest setEncoding(String encoding) {
-        if (StringUtils.isNotEmpty(encoding)) {
+        if (encoding != null && !encoding.isEmpty()) {
             this.encoding = encoding;
         } else {
             this.encoding = DEFAULT_ENCODING;

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
@@ -33,7 +33,6 @@ import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @deprecated Scripting support for Mojos is deprecated and is planned to be removed in Maven 4.0
@@ -62,7 +61,7 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
                 gatherFilesByBasedir(project.getBasedir(), project.getScriptSourceRoots(), scriptExtension, request);
 
         List<MojoDescriptor> mojoDescriptors;
-        if (!StringUtils.isEmpty(metadataExtension)) {
+        if (!(metadataExtension == null || metadataExtension.isEmpty())) {
             @SuppressWarnings("unchecked")
             Map<String, Set<File>> metadataFilesKeyedByBasedir = gatherFilesByBasedir(
                     project.getBasedir(), project.getScriptSourceRoots(), metadataExtension, request);

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocReference.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocReference.java
@@ -23,8 +23,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.codehaus.plexus.util.StringUtils;
-
 /**
  * Describes a code reference used in javadoc tags {@code see}, {@code link} and {@code linkplain}.
  * The format of the reference given as string is {@code module/package.class#member label}.
@@ -78,7 +76,7 @@ public class JavadocReference {
 
     private static Optional<String> getOptionalGroup(Matcher matcher, int index) {
         String group = matcher.group(index);
-        if (StringUtils.isNotEmpty(group)) {
+        if (group != null && !group.isEmpty()) {
             return Optional.of(group);
         } else {
             return Optional.empty();

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
@@ -39,7 +39,6 @@ import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractorComparator
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @author jdcasey
@@ -172,7 +171,7 @@ public class DefaultMojoScanner extends AbstractLogEnabled implements MojoScanne
             this.activeExtractors = new HashSet<>();
 
             for (String extractor : extractors) {
-                if (StringUtils.isNotEmpty(extractor)) {
+                if (extractor != null && !extractor.isEmpty()) {
                     this.activeExtractors.add(extractor);
                 }
             }

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/util/PluginUtils.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/util/PluginUtils.java
@@ -90,7 +90,7 @@ public final class PluginUtils {
         DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir(basedir);
         scanner.setIncludes(new String[] {include});
-        if (!StringUtils.isEmpty(exclude)) {
+        if (!(exclude == null || exclude.isEmpty())) {
             scanner.setExcludes(new String[] {exclude, StringUtils.join(FileUtils.getDefaultExcludes(), ",")});
         } else {
             scanner.setExcludes(FileUtils.getDefaultExcludes());

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/GeneratorUtils.java
@@ -174,7 +174,7 @@ public final class GeneratorUtils {
      */
     @Deprecated
     static String decodeJavadocTags(String description) {
-        if (StringUtils.isEmpty(description)) {
+        if (description == null || description.isEmpty()) {
             return "";
         }
 
@@ -198,13 +198,13 @@ public final class GeneratorUtils {
                 Matcher link = Pattern.compile(pattern).matcher(text);
                 if (link.matches()) {
                     text = link.group(label);
-                    if (StringUtils.isEmpty(text)) {
+                    if (text == null || text.isEmpty()) {
                         text = link.group(clazz);
-                        if (StringUtils.isEmpty(text)) {
+                        if (text == null || text.isEmpty()) {
                             text = "";
                         }
                         if (StringUtils.isNotEmpty(link.group(member))) {
-                            if (StringUtils.isNotEmpty(text)) {
+                            if (text != null && !text.isEmpty()) {
                                 text += '.';
                             }
                             text += link.group(member);
@@ -235,7 +235,7 @@ public final class GeneratorUtils {
     @Deprecated
     public static String makeHtmlValid(String description) {
 
-        if (StringUtils.isEmpty(description)) {
+        if (description == null || description.isEmpty()) {
             return "";
         }
 
@@ -258,7 +258,7 @@ public final class GeneratorUtils {
         tidy.parse(new ByteArrayInputStream(commentCleaned.getBytes(StandardCharsets.UTF_8)), out);
         commentCleaned = new String(out.toByteArray(), StandardCharsets.UTF_8);
 
-        if (StringUtils.isEmpty(commentCleaned)) {
+        if (commentCleaned == null || commentCleaned.isEmpty()) {
             return "";
         }
 
@@ -291,7 +291,7 @@ public final class GeneratorUtils {
      */
     @Deprecated
     public static String toText(String html) {
-        if (StringUtils.isEmpty(html)) {
+        if (html == null || html.isEmpty()) {
             return "";
         }
 

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
@@ -241,7 +241,7 @@ public class PluginDescriptorFilesGenerator implements Generator {
 
         String description = mojoDescriptor.getDescription();
 
-        if (StringUtils.isNotEmpty(description)) {
+        if (description != null && !description.isEmpty()) {
             w.startElement("description");
             w.writeText(getTextValue(type, containsXhtmlTextValues, mojoDescriptor.getDescription()));
             w.endElement();
@@ -438,7 +438,7 @@ public class PluginDescriptorFilesGenerator implements Generator {
             for (Parameter parameter : parameters) {
                 String expression = getExpression(parameter);
 
-                if (StringUtils.isNotEmpty(expression) && expression.startsWith("${component.")) {
+                if ((expression != null && !expression.isEmpty()) && expression.startsWith("${component.")) {
                     // treat it as a component...a requirement, in other words.
 
                     // remove "component." plus expression delimiters
@@ -535,7 +535,7 @@ public class PluginDescriptorFilesGenerator implements Generator {
 
                 // strip type by parameter type (generics) information
                 String parameterType = StringUtils.chomp(parameter.getType(), "<");
-                if (StringUtils.isNotEmpty(parameterType)) {
+                if (parameterType != null && !parameterType.isEmpty()) {
                     w.addAttribute("implementation", parameterType);
                 }
 

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -31,7 +31,6 @@ import org.apache.velocity.VelocityContext;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.codehaus.plexus.velocity.VelocityComponent;
 
@@ -146,7 +145,7 @@ public class PluginHelpGenerator extends AbstractLogEnabled {
      * @return The implementation.
      */
     private String getImplementation() {
-        return StringUtils.isEmpty(helpPackageName)
+        return (helpPackageName == null || helpPackageName.isEmpty())
                 ? HELP_MOJO_CLASS_NAME
                 : helpPackageName + '.' + HELP_MOJO_CLASS_NAME;
     }

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginXdocGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginXdocGenerator.java
@@ -286,7 +286,7 @@ public class PluginXdocGenerator implements Generator {
         }
 
         value = mojoDescriptor.isDependencyResolutionRequired();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.dependencyResolutionRequired", value));
@@ -297,7 +297,7 @@ public class PluginXdocGenerator implements Generator {
             ExtendedMojoDescriptor extendedMojoDescriptor = (ExtendedMojoDescriptor) mojoDescriptor;
 
             value = extendedMojoDescriptor.getDependencyCollectionRequired();
-            if (StringUtils.isNotEmpty(value)) {
+            if (value != null && !value.isEmpty()) {
                 addedUl = addUl(w, addedUl);
                 w.startElement("li");
                 w.writeMarkup(format("pluginxdoc.mojodescriptor.dependencyCollectionRequired", value));
@@ -314,7 +314,7 @@ public class PluginXdocGenerator implements Generator {
         w.endElement(); // li
 
         value = mojoDescriptor.getSince();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.since", value));
@@ -322,7 +322,7 @@ public class PluginXdocGenerator implements Generator {
         }
 
         value = mojoDescriptor.getPhase();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.phase", value));
@@ -330,7 +330,7 @@ public class PluginXdocGenerator implements Generator {
         }
 
         value = mojoDescriptor.getExecutePhase();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.executePhase", value));
@@ -338,7 +338,7 @@ public class PluginXdocGenerator implements Generator {
         }
 
         value = mojoDescriptor.getExecuteGoal();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.executeGoal", value));
@@ -346,7 +346,7 @@ public class PluginXdocGenerator implements Generator {
         }
 
         value = mojoDescriptor.getExecuteLifecycle();
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             addedUl = addUl(w, addedUl);
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.mojodescriptor.executeLifecycle", value));
@@ -565,7 +565,7 @@ public class PluginXdocGenerator implements Generator {
     }
 
     private boolean addUl(XMLWriter w, boolean addedUl, String content) {
-        if (StringUtils.isNotEmpty(content)) {
+        if (content != null && !content.isEmpty()) {
             return addUl(w, addedUl);
         }
         return addedUl;
@@ -580,7 +580,7 @@ public class PluginXdocGenerator implements Generator {
     }
 
     private String getPropertyFromExpression(String expression) {
-        if (StringUtils.isNotEmpty(expression)
+        if ((expression != null && !expression.isEmpty())
                 && expression.startsWith("${")
                 && expression.endsWith("}")
                 && !expression.substring(2).contains("${")) {
@@ -597,7 +597,7 @@ public class PluginXdocGenerator implements Generator {
      * @param w     not null
      */
     private void writeDetail(String param, String value, XMLWriter w) {
-        if (StringUtils.isNotEmpty(value)) {
+        if (value != null && !value.isEmpty()) {
             w.startElement("li");
             w.writeMarkup(format("pluginxdoc.detail", new String[] {param, value}));
             w.endElement(); // li

--- a/maven-plugin-tools-java/src/main/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaJavadocMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-java/src/main/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaJavadocMojoDescriptorExtractor.java
@@ -51,7 +51,6 @@ import org.apache.maven.tools.plugin.extractor.GroupKey;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractor;
 import org.apache.maven.tools.plugin.util.PluginUtils;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * <p>
@@ -218,7 +217,7 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
         if (requiresDependencyResolution != null) {
             String v = requiresDependencyResolution.getValue();
 
-            if (StringUtils.isEmpty(v)) {
+            if (v == null || v.isEmpty()) {
                 v = "runtime";
             }
 
@@ -231,7 +230,7 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
         if (requiresDependencyCollection != null) {
             String v = requiresDependencyCollection.getValue();
 
-            if (StringUtils.isEmpty(v)) {
+            if (v == null || v.isEmpty()) {
                 v = "runtime";
             }
 
@@ -296,7 +295,7 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
         if (tag != null) {
             String value = tag.getValue();
 
-            if (StringUtils.isNotEmpty(value)) {
+            if (value != null && !value.isEmpty()) {
                 defaultValue = Boolean.valueOf(value).booleanValue();
             }
         }
@@ -318,7 +317,7 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
         if (tag != null) {
             String value = tag.getValue();
 
-            if (StringUtils.isNotEmpty(value)) {
+            if (value != null && !value.isEmpty()) {
                 return Boolean.valueOf(value).booleanValue();
             } else {
                 return defaultForTag;
@@ -433,20 +432,20 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
 
                 String name = parameter.getNamedParameter(JavadocMojoAnnotation.PARAMETER_NAME);
 
-                if (!StringUtils.isEmpty(name)) {
+                if (!(name == null || name.isEmpty())) {
                     pd.setName(name);
                 }
 
                 String alias = parameter.getNamedParameter(JavadocMojoAnnotation.PARAMETER_ALIAS);
 
-                if (!StringUtils.isEmpty(alias)) {
+                if (!(alias == null || alias.isEmpty())) {
                     pd.setAlias(alias);
                 }
 
                 String expression = parameter.getNamedParameter(JavadocMojoAnnotation.PARAMETER_EXPRESSION);
                 String property = parameter.getNamedParameter(JavadocMojoAnnotation.PARAMETER_PROPERTY);
 
-                if (StringUtils.isNotEmpty(expression) && StringUtils.isNotEmpty(property)) {
+                if ((expression != null && !expression.isEmpty()) && (property != null && !property.isEmpty())) {
                     getLogger().error(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
                     getLogger().error("  Cannot use both:");
                     getLogger().error("    @parameter expression=\"${property}\"");
@@ -459,7 +458,7 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
                             null);
                 }
 
-                if (StringUtils.isNotEmpty(expression)) {
+                if (expression != null && !expression.isEmpty()) {
                     getLogger().warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
                     getLogger().warn("  The syntax");
                     getLogger().warn("    @parameter expression=\"${property}\"");
@@ -467,13 +466,13 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
                     getLogger().warn("    @parameter property=\"property\"");
                     getLogger().warn("  instead.");
 
-                } else if (StringUtils.isNotEmpty(property)) {
+                } else if (property != null && !property.isEmpty()) {
                     expression = "${" + property + "}";
                 }
 
                 pd.setExpression(expression);
 
-                if (StringUtils.isNotEmpty(expression) && expression.startsWith("${component.")) {
+                if ((expression != null && !expression.isEmpty()) && expression.startsWith("${component.")) {
                     getLogger().warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
                     getLogger().warn("  The syntax");
                     getLogger().warn("    @parameter expression=\"${component.<role>#<roleHint>}\"");

--- a/maven-script/maven-plugin-tools-ant/src/main/java/org/apache/maven/tools/plugin/extractor/ant/AntMojoDescriptorExtractor.java
+++ b/maven-script/maven-plugin-tools-ant/src/main/java/org/apache/maven/tools/plugin/extractor/ant/AntMojoDescriptorExtractor.java
@@ -40,7 +40,6 @@ import org.apache.maven.tools.plugin.extractor.GroupKey;
 import org.apache.maven.tools.plugin.extractor.model.PluginMetadataParseException;
 import org.apache.maven.tools.plugin.extractor.model.PluginMetadataParser;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Extracts Mojo descriptors from <a href="http://ant.apache.org">Ant</a> sources.
@@ -195,7 +194,7 @@ public class AntMojoDescriptorExtractor extends AbstractScriptedMojoDescriptorEx
                         String implementation = relativePath;
 
                         String dImpl = descriptor.getImplementation();
-                        if (StringUtils.isNotEmpty(dImpl)) {
+                        if (dImpl != null && !dImpl.isEmpty()) {
                             if (PluginMetadataParser.IMPL_BASE_PLACEHOLDER.equals(dImpl)) {
                                 implementation = relativePath;
                             } else {

--- a/maven-script/maven-plugin-tools-model/src/main/java/org/apache/maven/tools/plugin/extractor/model/PluginMetadataParser.java
+++ b/maven-script/maven-plugin-tools-model/src/main/java/org/apache/maven/tools/plugin/extractor/model/PluginMetadataParser.java
@@ -126,7 +126,7 @@ public class PluginMetadataParser {
                 dParam.setSince(param.getSince());
 
                 String property = param.getProperty();
-                if (StringUtils.isNotEmpty(property)) {
+                if (property != null && !property.isEmpty()) {
                     dParam.setName(property);
                 } else {
                     dParam.setName(param.getName());


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6825

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu

Review requested of @elharo 