### PR TITLE
[MPLUGIN-473] Only check direct dependencies for provided scope

### DIFF
--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-bad/verify.groovy
@@ -19,4 +19,4 @@
 
 File buildLog = new File( basedir, "build.log" );
 assert buildLog.isFile()
-assert buildLog.text.contains( "Some dependencies of Maven Plugins are expected to be in provided scope." )
+assert buildLog.text.contains( "Some direct dependencies of Maven Plugins are expected to be in provided scope." )

--- a/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/verify.groovy
+++ b/maven-plugin-plugin/src/it/mplugin-370-maven-deps-scope-good/verify.groovy
@@ -19,4 +19,4 @@
 
 File buildLog = new File( basedir, "build.log" );
 assert buildLog.isFile()
-assert !buildLog.text.contains( "Some dependencies of Maven Plugins are expected to be in provided scope." )
+assert !buildLog.text.contains( "Some direct dependencies of Maven Plugins are expected to be in provided scope." )


### PR DESCRIPTION
This relaxes the check a bit and provides support for plexus-xml 4.0.0
JIRA issue: https://issues.apache.org/jira/browse/MPLUGIN-473