### PR TITLE
[MPLUGIN-519][MPLUGIN-520] Parent POM 42, prerequisite of 3.6.3, get rid of maven-compat

### DIFF
--- a/maven-plugin-plugin/pom.xml
+++ b/maven-plugin-plugin/pom.xml
@@ -35,7 +35,7 @@
     in order to include them the resulting JAR. It is also used to generate a generic help goal.</description>
 
   <prerequisites>
-    <maven>${maven3Version}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>

--- a/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
+++ b/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
@@ -28,7 +28,7 @@ assert descriptorFile.isFile()
 def pluginDescriptor = new XmlParser().parse( descriptorFile );
 
 assert pluginDescriptor.requiredJavaVersion.text() == '1.8'
-assert pluginDescriptor.requiredMavenVersion.text() == '3.2.5'
+assert pluginDescriptor.requiredMavenVersion.text() == '3.9.6'
 
 def mojo = pluginDescriptor.mojos.mojo.findAll{ it.goal.text() == "first" }[0]
 

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -38,7 +38,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.settings.Settings;
 import org.apache.maven.tools.plugin.DefaultPluginToolsRequest;
 import org.apache.maven.tools.plugin.ExtendedPluginDescriptor;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
@@ -221,14 +220,6 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
     @Parameter(property = "internalJavadocVersion", defaultValue = "${java.version}")
     protected String internalJavadocVersion;
 
-    /**
-     * The Maven Settings, for evaluating proxy settings used to access {@link #javadocLinks}
-     *
-     * @since 3.7.0
-     */
-    @Component
-    private Settings settings;
-
     @Component
     private MavenSession mavenSession;
 
@@ -351,7 +342,7 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
             request.setInternalJavadocBaseUrl(internalJavadocBaseUrl);
             request.setInternalJavadocVersion(internalJavadocVersion);
             request.setExternalJavadocBaseUrls(externalJavadocBaseUrls);
-            request.setSettings(settings);
+            request.setSettings(mavenSession.getSettings());
 
             mojoScanner.populatePluginDescriptor(request);
             request.setPluginDescriptor(extendPluginDescriptor(request));

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
@@ -18,10 +18,8 @@
  */
 package org.apache.maven.plugin.plugin.metadata;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
 import org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata;
-import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -30,6 +28,10 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.RuntimeInformation;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.VersionScheme;
 
 /**
  * Inject any plugin-specific
@@ -69,6 +71,11 @@ public class AddPluginArtifactMetadataMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "maven.plugin.skip")
     private boolean skip;
 
+    @Component
+    private RuntimeInformation runtimeInformation;
+
+    private final VersionScheme versionScheme = new GenericVersionScheme();
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException {
@@ -76,18 +83,20 @@ public class AddPluginArtifactMetadataMojo extends AbstractMojo {
             getLog().warn("Execution skipped");
             return;
         }
-        Artifact projectArtifact = project.getArtifact();
+        // nothing if Maven is 3.9+
+        try {
+            if (versionScheme
+                            .parseVersion("3.9.0")
+                            .compareTo(versionScheme.parseVersion(runtimeInformation.getMavenVersion()))
+                    < 1) {
+                return;
+            }
+        } catch (InvalidVersionSpecificationException e) {
+            // not happening with generic
+            throw new MojoExecutionException(e);
+        }
 
-        Versioning versioning = new Versioning();
-        versioning.setLatest(projectArtifact.getVersion());
-        versioning.updateTimestamp();
-        ArtifactRepositoryMetadata metadata = new ArtifactRepositoryMetadata(projectArtifact, versioning);
-        projectArtifact.addMetadata(metadata);
-
-        GroupRepositoryMetadata groupMetadata = new GroupRepositoryMetadata(project.getGroupId());
-        groupMetadata.addPluginMapping(getGoalPrefix(), project.getArtifactId(), project.getName());
-
-        projectArtifact.addMetadata(groupMetadata);
+        LegacySupport.execute(project, getGoalPrefix());
     }
 
     /**

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.plugin.plugin.metadata;
 
-import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
-import org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -44,8 +42,8 @@ import org.eclipse.aether.version.VersionScheme;
  * <li>to define plugin mapping in the group</li>
  * </ol>
  *
- * @see ArtifactRepositoryMetadata
- * @see GroupRepositoryMetadata
+ * @see org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata
+ * @see org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata
  *
  * @since 2.0
  */

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/AddPluginArtifactMetadataMojo.java
@@ -89,6 +89,7 @@ public class AddPluginArtifactMetadataMojo extends AbstractMojo {
                             .parseVersion("3.9.0")
                             .compareTo(versionScheme.parseVersion(runtimeInformation.getMavenVersion()))
                     < 1) {
+                getLog().info("This Mojo is not used in Maven version 3.9.0 and above");
                 return;
             }
         } catch (InvalidVersionSpecificationException e) {

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/LegacySupport.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/metadata/LegacySupport.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.plugin.metadata;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.metadata.ArtifactRepositoryMetadata;
+import org.apache.maven.artifact.repository.metadata.GroupRepositoryMetadata;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+
+public class LegacySupport {
+    public static void execute(MavenProject project, String goalPrefix) throws MojoExecutionException {
+        Artifact projectArtifact = project.getArtifact();
+        Versioning versioning = new Versioning();
+        versioning.setLatest(projectArtifact.getVersion());
+        versioning.updateTimestamp();
+        ArtifactRepositoryMetadata metadata = new ArtifactRepositoryMetadata(projectArtifact, versioning);
+        projectArtifact.addMetadata(metadata);
+        GroupRepositoryMetadata groupMetadata = new GroupRepositoryMetadata(project.getGroupId());
+        groupMetadata.addPluginMapping(goalPrefix, project.getArtifactId(), project.getName());
+        projectArtifact.addMetadata(groupMetadata);
+    }
+}

--- a/maven-plugin-report-plugin/pom.xml
+++ b/maven-plugin-report-plugin/pom.xml
@@ -34,7 +34,7 @@
   <description>The Plugin Report Plugin is used to create reports about the plugin being built.</description>
 
   <prerequisites>
-    <maven>${maven3Version}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>

--- a/maven-plugin-report-plugin/src/it/plugin-report-annotations/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-annotations/verify.groovy
@@ -27,7 +27,7 @@ assert !pluginInfo.text.contains('Memory')
 assert !pluginInfo.text.contains('Disk Space')
 // check JDK and Maven requirements
 assert pluginInfo.text.contains('1.8')
-assert pluginInfo.text.contains('3.2.5')
+assert pluginInfo.text.contains('3.6.3')
 
 // deprecated info and description
 assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t use test goals, do you?</div><br />')

--- a/maven-plugin-report-plugin/src/it/plugin-report-annotations/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-annotations/verify.groovy
@@ -27,7 +27,7 @@ assert !pluginInfo.text.contains('Memory')
 assert !pluginInfo.text.contains('Disk Space')
 // check JDK and Maven requirements
 assert pluginInfo.text.contains('1.8')
-assert pluginInfo.text.contains('3.6.3')
+assert pluginInfo.text.contains('3.9.6')
 
 // deprecated info and description
 assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t use test goals, do you?</div><br />')

--- a/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
@@ -26,7 +26,7 @@ assert !pluginInfo.text.contains('Memory')
 assert !pluginInfo.text.contains('Disk Space')
 // check JDK and Maven requirements
 assert pluginInfo.text.contains('1.8')
-assert pluginInfo.text.contains('3.6.3')
+assert pluginInfo.text.contains('3.9.6')
 
 // deprecated info and description
 assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t use test goals, do you?</div><br />')

--- a/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
@@ -26,7 +26,7 @@ assert !pluginInfo.text.contains('Memory')
 assert !pluginInfo.text.contains('Disk Space')
 // check JDK and Maven requirements
 assert pluginInfo.text.contains('1.8')
-assert pluginInfo.text.contains('3.2.5')
+assert pluginInfo.text.contains('3.6.3')
 
 // deprecated info and description
 assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t use test goals, do you?</div><br />')

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>41</version>
+    <version>42</version>
     <relativePath />
   </parent>
 
@@ -93,7 +93,7 @@
     <javaVersion>8</javaVersion>
     <pluginTestingHarnessVersion>3.3.0</pluginTestingHarnessVersion>
     <maven4Version>4.0.0-alpha-4</maven4Version>
-    <maven3Version>3.2.5</maven3Version>
+    <maven3Version>3.9.6</maven3Version>
     <slf4jVersion>1.7.36</slf4jVersion>
     <antVersion>1.10.14</antVersion>
     <maven.site.path>plugin-tools-archives/plugin-tools-LATEST</maven.site.path>
@@ -101,7 +101,7 @@
     maven-plugin-tools-annotations/src/main/java/o/a/m/tools/plugins/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor#CLASS_VERSION_TO_JAVA_STRING
     needs to be updated as well -->
     <asmVersion>9.7</asmVersion>
-    <plexusUtilsVersion>4.0.0</plexusUtilsVersion>
+    <plexusUtilsVersion>4.0.1</plexusUtilsVersion>
     <plexusXmlVersion>3.0.0</plexusXmlVersion>
     <reportingApiVersion>3.1.1</reportingApiVersion>
     <reportingImplVersion>3.2.0</reportingImplVersion>
@@ -374,6 +374,12 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>


### PR DESCRIPTION
Update parent POM to 42, up prerequisite to 3.6.3. As parent 42 removes implicit (sisu) indexing, added explicitly indexing to all modules, as I think they all need it (may be wrong here).

The Mojo `AddPluginArtifactMetadataMojo` pulls in classes that have transitive (classes) coming from maven-compat. In fact, this mojo is not required at all since Maven 3.9.0 as resolver handles all transparently.

---

https://issues.apache.org/jira/browse/MPLUGIN-519
https://issues.apache.org/jira/browse/MPLUGIN-520