### PR TITLE
[MPLUGIN-522] Prerequisites should be opt-in

### DIFF
--- a/maven-plugin-plugin/src/it/java-basic-annotations/pom.xml
+++ b/maven-plugin-plugin/src/it/java-basic-annotations/pom.xml
@@ -82,6 +82,8 @@ under the License.
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           <goalPrefix>prefix</goalPrefix>
+          <requiredJavaVersion>auto</requiredJavaVersion>
+          <requiredMavenVersion>auto</requiredMavenVersion>
         </configuration>
         <executions>
           <execution>

--- a/maven-plugin-plugin/src/it/v4api/pom.xml
+++ b/maven-plugin-plugin/src/it/v4api/pom.xml
@@ -66,6 +66,8 @@ under the License.
         <version>@project.version@</version>
         <configuration>
           <goalPrefix>prefix</goalPrefix>
+          <requiredJavaVersion>auto</requiredJavaVersion>
+          <requiredMavenVersion>auto</requiredMavenVersion>
         </configuration>
         <executions>
           <execution>

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -233,11 +233,12 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
      * form for {@code "[1.8,)"}, i.e. denotes the minimum version required.</li>
      * <li>{@code "auto"} to determine the minimum Java version from the binary class version being generated during
      * compilation (determined by the extractor).</li>
+     * <li>By default is not set.</li>
      * </ul>
      *
      * @since 3.8.0
      */
-    @Parameter(defaultValue = VALUE_AUTO)
+    @Parameter
     String requiredJavaVersion;
 
     /**
@@ -250,13 +251,14 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
      * form for {@code "[2.2.1,)"}, i.e. denotes the minimum version required.</li>
      * <li>{@code "auto"} to determine the minimum Maven version from the POM's Maven prerequisite, or if not set the
      * referenced Maven Plugin API version.</li>
+     * <li>By default is not set.</li>
      * </ul>
      * This value takes precedence over the
      * <a href="https://maven.apache.org/pom.html#Prerequisites">POM's Maven prerequisite</a> in Maven 4.
      *
      * @since 3.8.0
      */
-    @Parameter(defaultValue = VALUE_AUTO)
+    @Parameter
     String requiredMavenVersion;
 
     /**

--- a/maven-plugin-report-plugin/src/it/plugin-report-annotations/pom.xml
+++ b/maven-plugin-report-plugin/src/it/plugin-report-annotations/pom.xml
@@ -91,6 +91,8 @@ under the License.
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           <goalPrefix>prefix</goalPrefix>
+          <requiredJavaVersion>auto</requiredJavaVersion>
+          <requiredMavenVersion>auto</requiredMavenVersion>
         </configuration>
         <executions>
           <execution>

--- a/maven-plugin-report-plugin/src/it/plugin-report/pom.xml
+++ b/maven-plugin-report-plugin/src/it/plugin-report/pom.xml
@@ -87,6 +87,8 @@ under the License.
         <version>@project.version@</version>
         <configuration>
           <goalPrefix>prefix</goalPrefix>
+          <requiredJavaVersion>auto</requiredJavaVersion>
+          <requiredMavenVersion>auto</requiredMavenVersion>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
But they are not. In fact, if user does not deal with them, they are way too aggressive and in fact, plain wrong.

Prerequisite was opt-in and should have remain opt-in.

---

https://issues.apache.org/jira/browse/MPLUGIN-522