### PR TITLE
Build with JDK 17 and 21 in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpPlgnBuild()
+asfMavenTlpPlgnBuild(jdks:[ "17", "21" ])


### PR DESCRIPTION
Not needed for now, as we still support Maven 3 plugins.