### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -99,7 +99,7 @@ import org.slf4j.LoggerFactory;
 @Named(JavaAnnotationsMojoDescriptorExtractor.NAME)
 @Singleton
 public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExtractor {
-    private static final Logger logger = LoggerFactory.getLogger(JavaAnnotationsMojoDescriptorExtractor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaAnnotationsMojoDescriptorExtractor.class);
     public static final String NAME = "java-annotations";
 
     private static final GroupKey GROUP_KEY = new GroupKey(GroupKey.JAVA_GROUP, 100);
@@ -450,7 +450,7 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            logger.warn("Failed extracting tag '" + tagName + "' from class " + str);
+            LOGGER.warn("Failed extracting tag '" + tagName + "' from class " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -490,7 +490,7 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
 
             return rawParams;
         } catch (NoClassDefFoundError e) {
-            logger.warn("Failed extracting parameters from " + javaClass);
+            LOGGER.warn("Failed extracting parameters from " + javaClass);
             throw e;
         }
     }
@@ -542,7 +542,7 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            logger.warn("Failed extracting methods from " + str);
+            LOGGER.warn("Failed extracting methods from " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -591,10 +591,10 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
             } catch (ArtifactResolutionException e) {
                 String message = "Unable to get sources artifact for " + artifact.getId()
                         + ". Some javadoc tags (@since, @deprecated and comments) won't be used";
-                if (logger.isDebugEnabled()) {
-                    logger.warn(message, e);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.warn(message, e);
                 } else {
-                    logger.warn(message);
+                    LOGGER.warn(message);
                 }
                 return;
             }

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -79,7 +79,6 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -87,6 +86,8 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JavaMojoDescriptorExtractor, a MojoDescriptor extractor to read descriptors from java classes with annotations.
@@ -97,7 +98,8 @@ import org.objectweb.asm.Opcodes;
  */
 @Named(JavaAnnotationsMojoDescriptorExtractor.NAME)
 @Singleton
-public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled implements MojoDescriptorExtractor {
+public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExtractor {
+    private static final Logger logger = LoggerFactory.getLogger(JavaAnnotationsMojoDescriptorExtractor.class);
     public static final String NAME = "java-annotations";
 
     private static final GroupKey GROUP_KEY = new GroupKey(GroupKey.JAVA_GROUP, 100);
@@ -448,7 +450,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            getLogger().warn("Failed extracting tag '" + tagName + "' from class " + str);
+            logger.warn("Failed extracting tag '" + tagName + "' from class " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -488,7 +490,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
 
             return rawParams;
         } catch (NoClassDefFoundError e) {
-            getLogger().warn("Failed extracting parameters from " + javaClass);
+            logger.warn("Failed extracting parameters from " + javaClass);
             throw e;
         }
     }
@@ -540,7 +542,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            getLogger().warn("Failed extracting methods from " + str);
+            logger.warn("Failed extracting methods from " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -589,10 +591,10 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (ArtifactResolutionException e) {
                 String message = "Unable to get sources artifact for " + artifact.getId()
                         + ". Some javadoc tags (@since, @deprecated and comments) won't be used";
-                if (getLogger().isDebugEnabled()) {
-                    getLogger().warn(message, e);
+                if (logger.isDebugEnabled()) {
+                    logger.warn(message, e);
                 } else {
-                    getLogger().warn(message);
+                    logger.warn(message);
                 }
                 return;
             }

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 @Named
 @Singleton
 public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
-    private static final Logger logger = LoggerFactory.getLogger(DefaultMojoAnnotationsScanner.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMojoAnnotationsScanner.class);
     public static final String MVN4_API = "org.apache.maven.api.plugin.annotations.";
     public static final String MOJO_V4 = MVN4_API + "Mojo";
     public static final String EXECUTE_V4 = MVN4_API + "Execute";
@@ -176,7 +176,7 @@ public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
             }
         } catch (IllegalArgumentException e) {
             // In case of a class with newer specs an IllegalArgumentException can be thrown
-            logger.error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
+            LOGGER.error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
 
             throw e;
         }
@@ -234,15 +234,15 @@ public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
             ClassReader rdr = new ClassReader(is);
             rdr.accept(mojoClassVisitor, ClassReader.SKIP_FRAMES | ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
         } catch (ArrayIndexOutOfBoundsException aiooe) {
-            logger.warn(
-                            "Error analyzing class " + file + " in " + source + ": ignoring class",
-                            logger.isDebugEnabled() ? aiooe : null);
+            LOGGER.warn(
+                    "Error analyzing class " + file + " in " + source + ": ignoring class",
+                    LOGGER.isDebugEnabled() ? aiooe : null);
             return;
         } catch (IllegalArgumentException iae) {
             if (iae.getMessage() == null) {
-                logger.warn(
-                                "Error analyzing class " + file + " in " + source + ": ignoring class",
-                                logger.isDebugEnabled() ? iae : null);
+                LOGGER.warn(
+                        "Error analyzing class " + file + " in " + source + ": ignoring class",
+                        LOGGER.isDebugEnabled() ? iae : null);
                 return;
             } else {
                 throw iae;
@@ -259,9 +259,9 @@ public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
 
         if (mojoAnnotatedClass != null) // see MPLUGIN-206 we can have intermediate classes without annotations
         {
-            if (logger.isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
-                logger.debug("found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":"
-                                + mojoAnnotatedClass);
+            if (LOGGER.isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
+                LOGGER.debug(
+                        "found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":" + mojoAnnotatedClass);
             }
             mojoAnnotatedClass.setArtifact(artifact);
             mojoAnnotatedClasses.put(mojoAnnotatedClass.getClassName(), mojoAnnotatedClass);

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
@@ -50,13 +50,14 @@ import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.Mojo
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoClassVisitor;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoFieldVisitor;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoParameterVisitor;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.reflection.Reflector;
 import org.codehaus.plexus.util.reflection.ReflectorException;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Mojo scanner with java annotations.
@@ -66,7 +67,8 @@ import org.objectweb.asm.Type;
  */
 @Named
 @Singleton
-public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements MojoAnnotationsScanner {
+public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMojoAnnotationsScanner.class);
     public static final String MVN4_API = "org.apache.maven.api.plugin.annotations.";
     public static final String MOJO_V4 = MVN4_API + "Mojo";
     public static final String EXECUTE_V4 = MVN4_API + "Execute";
@@ -174,7 +176,7 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
             }
         } catch (IllegalArgumentException e) {
             // In case of a class with newer specs an IllegalArgumentException can be thrown
-            getLogger().error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
+            logger.error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
 
             throw e;
         }
@@ -232,17 +234,15 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
             ClassReader rdr = new ClassReader(is);
             rdr.accept(mojoClassVisitor, ClassReader.SKIP_FRAMES | ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
         } catch (ArrayIndexOutOfBoundsException aiooe) {
-            getLogger()
-                    .warn(
+            logger.warn(
                             "Error analyzing class " + file + " in " + source + ": ignoring class",
-                            getLogger().isDebugEnabled() ? aiooe : null);
+                            logger.isDebugEnabled() ? aiooe : null);
             return;
         } catch (IllegalArgumentException iae) {
             if (iae.getMessage() == null) {
-                getLogger()
-                        .warn(
+                logger.warn(
                                 "Error analyzing class " + file + " in " + source + ": ignoring class",
-                                getLogger().isDebugEnabled() ? iae : null);
+                                logger.isDebugEnabled() ? iae : null);
                 return;
             } else {
                 throw iae;
@@ -259,9 +259,8 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
 
         if (mojoAnnotatedClass != null) // see MPLUGIN-206 we can have intermediate classes without annotations
         {
-            if (getLogger().isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
-                getLogger()
-                        .debug("found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":"
+            if (logger.isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
+                logger.debug("found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":"
                                 + mojoAnnotatedClass);
             }
             mojoAnnotatedClass.setArtifact(artifact);

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
@@ -35,13 +35,11 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.DefaultPluginToolsRequest;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner;
-import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class JavaAnnotationsMojoDescriptorExtractorTest {
     @TempDir

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
@@ -55,7 +55,6 @@ class JavaAnnotationsMojoDescriptorExtractorTest {
         Files.copy(sourceClass, targetDir.resolve(sourceClass.getFileName()));
         JavaAnnotationsMojoDescriptorExtractor mojoDescriptorExtractor = new JavaAnnotationsMojoDescriptorExtractor();
         DefaultMojoAnnotationsScanner scanner = new DefaultMojoAnnotationsScanner();
-        scanner.enableLogging(mock(Logger.class));
         mojoDescriptorExtractor.mojoAnnotationsScanner = scanner;
         PluginDescriptor pluginDescriptor = new PluginDescriptor();
         MavenProject mavenProject = new MavenProject();

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
@@ -37,7 +37,6 @@ import org.apache.maven.tools.plugin.extractor.annotations.FooMojo;
 import org.apache.maven.tools.plugin.extractor.annotations.ParametersWithGenericsMojo;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ParameterAnnotationContent;
-import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 class DefaultMojoAnnotationsScannerTest {
     private DefaultMojoAnnotationsScanner scanner = new DefaultMojoAnnotationsScanner();

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
@@ -58,7 +58,6 @@ class DefaultMojoAnnotationsScannerTest {
 
     @Test
     void testJava8Annotations() throws Exception {
-        scanner.enableLogging(mock(Logger.class));
         scanner.scanArchive(new File("target/test-classes/java8-annotations.jar"), null, false);
     }
 
@@ -66,7 +65,6 @@ class DefaultMojoAnnotationsScannerTest {
     void scanDeprecatedMojoAnnotatins() throws ExtractionException, IOException {
         File directoryToScan = new File(DeprecatedMojo.class.getResource("").getFile());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> result =
                 scanner.scanDirectory(directoryToScan, Collections.singletonList("DeprecatedMojo.class"), null, false);
 
@@ -94,7 +92,6 @@ class DefaultMojoAnnotationsScannerTest {
         File directoryToScan =
                 new File(ParametersWithGenericsMojo.class.getResource("").getFile());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> result = scanner.scanDirectory(
                 directoryToScan, Collections.singletonList("ParametersWithGenericsMojo**.class"), null, false);
 
@@ -147,7 +144,6 @@ class DefaultMojoAnnotationsScannerTest {
         request.setIncludePatterns(Arrays.asList("**/FooMojo.class"));
         request.setProject(new MavenProject());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> mojoAnnotatedClasses = scanner.scan(request);
 
         System.out.println("mojoAnnotatedClasses:" + mojoAnnotatedClasses);

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
@@ -40,9 +40,8 @@ import org.slf4j.LoggerFactory;
  * @author jdcasey
  */
 @Deprecated
-public abstract class AbstractScriptedMojoDescriptorExtractor
-        implements MojoDescriptorExtractor {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractScriptedMojoDescriptorExtractor.class);
+public abstract class AbstractScriptedMojoDescriptorExtractor implements MojoDescriptorExtractor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractScriptedMojoDescriptorExtractor.class);
 
     @Override
     public boolean isDeprecated() {
@@ -53,7 +52,7 @@ public abstract class AbstractScriptedMojoDescriptorExtractor
     @Override
     public List<MojoDescriptor> execute(PluginToolsRequest request)
             throws ExtractionException, InvalidPluginDescriptorException {
-        logger.debug("Running: " + getClass().getName());
+        LOGGER.debug("Running: " + getClass().getName());
         String metadataExtension = getMetadataFileExtension(request);
         String scriptExtension = getScriptFileExtension(request);
 
@@ -78,8 +77,8 @@ public abstract class AbstractScriptedMojoDescriptorExtractor
                 scriptFilesKeyedByBasedir, project.getBuild().getOutputDirectory(), request);
 
         if (!mojoDescriptors.isEmpty()) {
-            logger.warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
-            logger.warn("Found " + mojoDescriptors.size() + " scripted mojos.");
+            LOGGER.warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
+            LOGGER.warn("Found " + mojoDescriptors.size() + " scripted mojos.");
         }
 
         return mojoDescriptors;
@@ -143,8 +142,8 @@ public abstract class AbstractScriptedMojoDescriptorExtractor
         for (String resourceDir : directories) {
             Set<File> sources = new HashSet<>();
 
-            logger.debug("Scanning script dir: " + resourceDir + " with extractor: "
-                            + getClass().getName());
+            LOGGER.debug("Scanning script dir: " + resourceDir + " with extractor: "
+                    + getClass().getName());
             File dir = new File(resourceDir);
             if (!dir.isAbsolute()) {
                 dir = new File(basedir, resourceDir).getAbsoluteFile();

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
@@ -30,17 +30,20 @@ import org.apache.maven.plugin.descriptor.InvalidPluginDescriptorException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @deprecated Scripting support for Mojos is deprecated and is planned to be removed in Maven 4.0
  * @author jdcasey
  */
 @Deprecated
-public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLogEnabled
+public abstract class AbstractScriptedMojoDescriptorExtractor
         implements MojoDescriptorExtractor {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractScriptedMojoDescriptorExtractor.class);
+
     @Override
     public boolean isDeprecated() {
         return true;
@@ -50,7 +53,7 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
     @Override
     public List<MojoDescriptor> execute(PluginToolsRequest request)
             throws ExtractionException, InvalidPluginDescriptorException {
-        getLogger().debug("Running: " + getClass().getName());
+        logger.debug("Running: " + getClass().getName());
         String metadataExtension = getMetadataFileExtension(request);
         String scriptExtension = getScriptFileExtension(request);
 
@@ -75,8 +78,8 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
                 scriptFilesKeyedByBasedir, project.getBuild().getOutputDirectory(), request);
 
         if (!mojoDescriptors.isEmpty()) {
-            getLogger().warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
-            getLogger().warn("Found " + mojoDescriptors.size() + " scripted mojos.");
+            logger.warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
+            logger.warn("Found " + mojoDescriptors.size() + " scripted mojos.");
         }
 
         return mojoDescriptors;
@@ -140,8 +143,7 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
         for (String resourceDir : directories) {
             Set<File> sources = new HashSet<>();
 
-            getLogger()
-                    .debug("Scanning script dir: " + resourceDir + " with extractor: "
+            logger.debug("Scanning script dir: " + resourceDir + " with extractor: "
                             + getClass().getName());
             File dir = new File(resourceDir);
             if (!dir.isAbsolute()) {

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 @Named
 public class DefaultMojoScanner implements MojoScanner {
-    private static final Logger logger = LoggerFactory.getLogger(DefaultMojoScanner.class);
+    private static final Logger logger = LoggerFactory.getLogger("standalone-scanner-logger");
 
     private Map<String, MojoDescriptorExtractor> mojoDescriptorExtractors;
 
@@ -62,8 +62,6 @@ public class DefaultMojoScanner implements MojoScanner {
     @Inject
     public DefaultMojoScanner(Map<String, MojoDescriptorExtractor> extractors) {
         this.mojoDescriptorExtractors = extractors;
-
-        this.enableLogging(new ConsoleLogger(Logger.LEVEL_INFO, "standalone-scanner-logger"));
     }
 
     /**

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
@@ -36,15 +36,16 @@ import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.extractor.GroupKey;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractor;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractorComparator;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author jdcasey
  */
 @Named
-public class DefaultMojoScanner extends AbstractLogEnabled implements MojoScanner {
+public class DefaultMojoScanner implements MojoScanner {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMojoScanner.class);
 
     private Map<String, MojoDescriptorExtractor> mojoDescriptorExtractors;
 
@@ -78,7 +79,6 @@ public class DefaultMojoScanner extends AbstractLogEnabled implements MojoScanne
     @Override
     public void populatePluginDescriptor(PluginToolsRequest request)
             throws ExtractionException, InvalidPluginDescriptorException {
-        Logger logger = getLogger();
 
         int numMojoDescriptors = 0;
 

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/scanner/DefaultMojoScanner.java
@@ -36,7 +36,6 @@ import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.extractor.GroupKey;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractor;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractorComparator;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 @Named
 public class DefaultMojoScanner implements MojoScanner {
-    private static final Logger logger = LoggerFactory.getLogger("standalone-scanner-logger");
+    private static final Logger LOGGER = LoggerFactory.getLogger("standalone-scanner-logger");
 
     private Map<String, MojoDescriptorExtractor> mojoDescriptorExtractors;
 
@@ -82,7 +81,7 @@ public class DefaultMojoScanner implements MojoScanner {
 
         List<MojoDescriptorExtractor> orderedExtractors = getOrderedExtractors();
 
-        logger.debug("Using " + orderedExtractors.size() + " mojo extractors.");
+        LOGGER.debug("Using " + orderedExtractors.size() + " mojo extractors.");
 
         HashMap<String, Integer> groupStats = new HashMap<>();
 
@@ -90,26 +89,26 @@ public class DefaultMojoScanner implements MojoScanner {
             GroupKey groupKey = extractor.getGroupKey();
             String extractorId = extractor.getName();
 
-            logger.debug("Applying " + extractorId + " mojo extractor");
+            LOGGER.debug("Applying " + extractorId + " mojo extractor");
 
             List<MojoDescriptor> extractorDescriptors = extractor.execute(request);
 
             int extractorDescriptorsCount = extractorDescriptors.size();
 
-            logger.info(extractorId + " mojo extractor found " + extractorDescriptorsCount + " mojo descriptor"
+            LOGGER.info(extractorId + " mojo extractor found " + extractorDescriptorsCount + " mojo descriptor"
                     + (extractorDescriptorsCount > 1 ? "s" : "") + ".");
             numMojoDescriptors += extractorDescriptorsCount;
 
             if (extractor.isDeprecated() && extractorDescriptorsCount > 0) {
-                logger.warn("");
-                logger.warn("Deprecated extractor " + extractorId
+                LOGGER.warn("");
+                LOGGER.warn("Deprecated extractor " + extractorId
                         + " extracted " + extractorDescriptorsCount
                         + " descriptor" + (extractorDescriptorsCount > 1 ? "s" : "")
                         + ". Upgrade your Mojo definitions.");
                 if (GroupKey.JAVA_GROUP.equals(groupKey.getGroup())) {
-                    logger.warn("You should use Mojo Annotations instead of Javadoc tags.");
+                    LOGGER.warn("You should use Mojo Annotations instead of Javadoc tags.");
                 }
-                logger.warn("");
+                LOGGER.warn("");
             }
 
             if (groupStats.containsKey(groupKey.getGroup())) {
@@ -119,7 +118,7 @@ public class DefaultMojoScanner implements MojoScanner {
             }
 
             for (MojoDescriptor descriptor : extractorDescriptors) {
-                logger.debug("Adding mojo: " + descriptor + " to plugin descriptor.");
+                LOGGER.debug("Adding mojo: " + descriptor + " to plugin descriptor.");
 
                 descriptor.setPluginDescriptor(request.getPluginDescriptor());
 
@@ -127,7 +126,7 @@ public class DefaultMojoScanner implements MojoScanner {
             }
         }
 
-        logger.debug("Discovered descriptors by groups: " + groupStats);
+        LOGGER.debug("Discovered descriptors by groups: " + groupStats);
 
         if (numMojoDescriptors == 0 && !request.isSkipErrorNoDescriptorsFound()) {
             throw new InvalidPluginDescriptorException("No mojo definitions were found for plugin: "

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -61,7 +61,7 @@ public class PluginHelpGenerator {
      * Default constructor
      */
     public PluginHelpGenerator() {
-        this.enableLogging(new ConsoleLogger(Logger.LEVEL_INFO, "PluginHelpGenerator"));
+        // nop
     }
 
     // ----------------------------------------------------------------------

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -30,8 +30,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.velocity.VelocityContext;
 import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.codehaus.plexus.velocity.VelocityComponent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -44,7 +42,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @since 2.4
  */
 public class PluginHelpGenerator {
-    private static final Logger logger = LoggerFactory.getLogger(PluginHelpGenerator.class);
     /**
      * Default generated class name
      */

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -28,11 +28,11 @@ import java.io.Writer;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.velocity.VelocityContext;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.codehaus.plexus.velocity.VelocityComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -44,7 +44,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 2.4
  */
-public class PluginHelpGenerator extends AbstractLogEnabled {
+public class PluginHelpGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(PluginHelpGenerator.class);
     /**
      * Default generated class name
      */

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -28,7 +28,6 @@ import java.io.Writer;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.velocity.VelocityContext;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.codehaus.plexus.velocity.VelocityComponent;
 import org.slf4j.Logger;


### PR DESCRIPTION
As seen on https://cwiki.apache.org/confluence/plugins/servlet/mobile?contentId=181305684#MavenEcosystemCleanup-DropPlexusContainerforJSR-330+SisuGuiceextension

- Leverages https://github.com/openrewrite/rewrite-apache/pull/41

I have another two lined up for apache/maven and apache/maven-archetype that I'll verify first.

@elharo if you wouldn't mind, could you look this over?

Use this link to re-run the recipe: https://app.moderne.io/builder/P4zH7djn6?organizationId=QXBhY2hlIE1hdmVu