### PR TITLE
[MPLUGIN-542] Update QDox to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
       <dependency>
         <groupId>com.thoughtworks.qdox</groupId>
         <artifactId>qdox</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <!-- for XHTML to plain text and HTML to XHTML conversion -->
       <dependency>


### PR DESCRIPTION
This fixes parsing of annotations leveraging textblocks (https://github.com/paul-hammant/qdox/issues/124)