### PR TITLE
docs: Remove (non-functional) JIRA `README.md` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Additional Resources
 --------------------
 
 + [Contributing patches](https://maven.apache.org/guides/development/guide-maven-development.html#Creating_and_submitting_a_patch)
-+ [Apache Maven Plugin Tools JIRA project page][jira]
 + [Contributor License Agreement][cla]
 + [General GitHub documentation](https://help.github.com/)
 + [GitHub pull request documentation](https://help.github.com/send-pull-requests/)


### PR DESCRIPTION
In https://github.com/apache/maven-plugin-tools/commit/5364f90ecedc53193e3b2fe24705025a18af6dce, the repo was updated to reference GitHub issues instead of a JIRA instance - but a reference to `[jira]` was missed and the link is now broken:

![image](https://github.com/user-attachments/assets/a4942bec-b259-4488-bde0-cc5a597c6b68)

Removed reference.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)