### PR TITLE
Architectural refactor: rename *-mojo.html report output to goal

### DIFF
--- a/maven-plugin-plugin/src/site/apt/index.apt
+++ b/maven-plugin-plugin/src/site/apt/index.apt
@@ -36,14 +36,14 @@ Maven Plugin Plugin
 
    The Plugin Plugin has four goals:
 
-   * {{{./descriptor-mojo.html}plugin:descriptor}} generates a plugin descriptor,
+   * {{{./descriptor-goal.html}plugin:descriptor}} generates a plugin descriptor,
 
-   * {{{./addPluginArtifactMetadata-mojo.html}plugin:addPluginArtifactMetadata}} injects any plugin-specific artifact
+   * {{{./addPluginArtifactMetadata-goal.html}plugin:addPluginArtifactMetadata}} injects any plugin-specific artifact
       metadata to the project's artifact, for subsequent installation and deployment,
 
-   * {{{./helpmojo-mojo.html}plugin:helpmojo}} generates a help mojo which describes all mojos in a plugin,
+   * {{{./helpmojo-goal.html}plugin:helpmojo}} generates a help mojo which describes all mojos in a plugin,
 
-   * {{{./help-mojo.html}plugin:help}} display help information on maven-plugin-plugin.
+   * {{{./help-goal.html}plugin:help}} display help information on maven-plugin-plugin.
 
    []
 

--- a/maven-plugin-report-plugin/src/it/fix-maven-since-3.x/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/fix-maven-since-3.x/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-File touchFile = new File( basedir, "javasample-maven-plugin/target/site/touch-mojo.html" )
+File touchFile = new File( basedir, "javasample-maven-plugin/target/site/touch-goal.html" )
 assert touchFile.exists()
 assert touchFile.isFile()
 content = touchFile.text

--- a/maven-plugin-report-plugin/src/it/mplugin-191/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/mplugin-191/verify.groovy
@@ -18,7 +18,7 @@
 File pluginInfo = new File( basedir, "target/site/plugin-info.html" );
 assert pluginInfo.isFile()
 
-File touchMojo = new File( basedir, "target/site/touch-mojo.html" );
+File touchMojo = new File( basedir, "target/site/touch-goal.html" );
 assert touchMojo.isFile()
 
 return true;

--- a/maven-plugin-report-plugin/src/it/mplugin-319_report-since/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/mplugin-319_report-since/verify.groovy
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-assert new File( basedir, 'target/site/noop-mojo.html' ).exists()
+assert new File( basedir, 'target/site/noop-goal.html' ).exists()
 
-content = new File( basedir, 'target/site/noop-mojo.html' ).text
+content = new File( basedir, 'target/site/noop-goal.html' ).text
 
 assert content.contains( '<li>Since version: <code>1.0</code>.</li>' )
 assert content.contains( '<td><code>-</code></td>' )

--- a/maven-plugin-report-plugin/src/it/mplugin-394_report-encoding/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/mplugin-394_report-encoding/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-generated = new File( basedir, "target/site/test-mojo.html").getText("UTF-8")
+generated = new File( basedir, "target/site/test-goal.html").getText("UTF-8")
 
 assert generated.contains("Mojo-Description with some non-ASCII characters: €àáâãäåæòóôõöø")
 assert generated.contains("Parameter-Description with some non-ASCII characters: ÈÉÊË€")

--- a/maven-plugin-report-plugin/src/it/plugin-no-fork-report/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-no-fork-report/verify.groovy
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-assert new File( basedir, 'target/site/noop-mojo.html' ).isFile()
-assert new File( basedir, 'target/site/report-mojo.html' ).isFile()
+assert new File( basedir, 'target/site/noop-goal.html' ).isFile()
+assert new File( basedir, 'target/site/report-goal.html' ).isFile()
 
 def pluginInfo = new File( basedir, 'target/site/plugin-info.html' )
 assert pluginInfo.isFile()
@@ -34,7 +34,7 @@ assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t us
 assert pluginInfo.text.contains('Does nothing.')
 
 
-def noopMojo = new File( basedir, 'target/site/noop-mojo.html' )
+def noopMojo = new File( basedir, 'target/site/noop-goal.html' )
 assert noopMojo.isFile()
 
 // deprecated in table and details

--- a/maven-plugin-report-plugin/src/it/plugin-report-detect-requirements-history/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-detect-requirements-history/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-assert new File( basedir, 'target/site/noop-mojo.html' ).isFile()
+assert new File( basedir, 'target/site/noop-goal.html' ).isFile()
 
 def pluginInfo = new File( basedir, 'target/site/plugin-info.html' )
 assert pluginInfo.isFile()

--- a/maven-plugin-report-plugin/src/it/plugin-report-requirements-history/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-requirements-history/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-assert new File( basedir, 'target/site/noop-mojo.html' ).isFile()
+assert new File( basedir, 'target/site/noop-goal.html' ).isFile()
 
 def pluginInfo = new File( basedir, 'target/site/plugin-info.html' )
 assert pluginInfo.isFile()

--- a/maven-plugin-report-plugin/src/it/plugin-report-with-javadoc-links/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-with-javadoc-links/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def mojoDoc = new File( basedir, 'target/site/test-mojo.html' )
+def mojoDoc = new File( basedir, 'target/site/test-goal.html' )
 
 assert mojoDoc.isFile()
 

--- a/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report/verify.groovy
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-assert new File( basedir, 'target/site/noop-mojo.html' ).isFile()
-assert new File( basedir, 'target/site/report-mojo.html' ).isFile()
+assert new File( basedir, 'target/site/noop-goal.html' ).isFile()
+assert new File( basedir, 'target/site/report-goal.html' ).isFile()
 
 def pluginInfo = new File( basedir, 'target/site/plugin-info.html' )
 assert pluginInfo.isFile()
@@ -34,7 +34,7 @@ assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t us
 assert pluginInfo.text.contains('Does nothing.')
 
 
-def noopMojo = new File( basedir, 'target/site/noop-mojo.html' )
+def noopMojo = new File( basedir, 'target/site/noop-goal.html' )
 assert noopMojo.isFile()
 
 // deprecated in table and details

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginNoForkReport.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginNoForkReport.java
@@ -24,8 +24,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Generates the plugin's report: the plugin details page at <code>plugin-info.html</code>,
- * and one <code><i>goal</i>-mojo.html</code> per goal.
- * Relies on one output file from <a href="../maven-plugin-plugin/descriptor-mojo.html">plugin:descriptor</a>.
+ * and one <code><i>goal</i>-goal.html</code> per goal.
+ * Relies on one output file from <a href="../maven-plugin-plugin/descriptor-goal.html">plugin:descriptor</a>.
  *
  * @since 3.14.0
  */

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginOverviewRenderer.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginOverviewRenderer.java
@@ -130,7 +130,7 @@ class PluginOverviewRenderer extends AbstractPluginReportRenderer {
              * Added ./ to define a relative path
              * @see AbstractMavenReportRenderer#getValidHref(java.lang.String)
              */
-            String goalDocumentationLink = "./" + mojo.getGoal() + "-mojo.html";
+            String goalDocumentationLink = "./" + mojo.getGoal() + "-goal.html";
             sink.tableCell();
             link(goalDocumentationLink, goalName);
             sink.tableCell_();

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginReport.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginReport.java
@@ -62,8 +62,8 @@ import org.eclipse.aether.version.Version;
 
 /**
  * Generates the plugin's report: the plugin details page at <code>plugin-info.html</code>
- * and one <code><i>goal</i>-mojo.html</code> per goal.
- * Relies on one output file from <a href="../maven-plugin-plugin/descriptor-mojo.html">plugin:descriptor</a>.
+ * and one <code><i>goal</i>-goal.html</code> per goal.
+ * Relies on one output file from <a href="../maven-plugin-plugin/descriptor-goal.html">plugin:descriptor</a>.
  *
  * @author <a href="snicoll@apache.org">Stephane Nicoll</a>
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
@@ -276,7 +276,7 @@ public class PluginReport extends AbstractMavenReport {
             for (MojoDescriptor descriptor : pluginDescriptor.getMojos()) {
                 GoalRenderer renderer;
                 try {
-                    String filename = descriptor.getGoal() + "-mojo.html";
+                    String filename = descriptor.getGoal() + "-goal.html";
                     Sink sink = getSinkFactory().createSink(getReportOutputDirectory(), filename);
                     renderer = new GoalRenderer(
                             sink,

--- a/maven-plugin-report-plugin/src/site/apt/index.apt
+++ b/maven-plugin-report-plugin/src/site/apt/index.apt
@@ -34,9 +34,9 @@ Maven Plugin Report Plugin
 
    The Plugin Report Plugin has two goals:
 
-  * {{{./report-mojo.html}plugin-report:report}} which generates the plugin documentation: one overview report and documentation for each plugin's goal (mojo).
+  * {{{./report-goal.html}plugin-report:report}} which generates the plugin documentation: one overview report and documentation for each plugin's goal (mojo).
 
-  * {{{./report-no-fork-mojo.html}plugin-report:report-no-fork}} which generates the plugin documentation: one overview report and documentation for each plugin's goal (mojo)  without forking the <<<process-classes>>> phase again. Note that this goal does require generation of classes before site generation, e.g. by invoking <<<mvn clean verify site>>>.
+  * {{{./report-no-fork-goal.html}plugin-report:report-no-fork}} which generates the plugin documentation: one overview report and documentation for each plugin's goal (mojo)  without forking the <<<process-classes>>> phase again. Note that this goal does require generation of classes before site generation, e.g. by invoking <<<mvn clean verify site>>>.
 
   []
 

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContext.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContext.java
@@ -170,7 +170,7 @@ public class JavaClassConverterContext implements ConverterContext {
                     // link to other mojo (only for fields = parameters or without member)
                     return new URI(
                             null,
-                            "./" + mojoAnnotatedClass.getMojo().name() + "-mojo.html",
+                            "./" + mojoAnnotatedClass.getMojo().name() + "-goal.html",
                             reference.getMember().orElse(null));
                 }
             }

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContextTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/converter/JavaClassConverterContextTest.java
@@ -235,7 +235,7 @@ class JavaClassConverterContextTest {
 
         // field reference in another mojo
         assertEquals(
-                new URI(null, "./other-goal-mojo.html", "field1"),
+                new URI(null, "./other-goal-goal.html", "field1"),
                 context.getUrl(new FullyQualifiedJavadocReference(
                         currentPackageName, "OtherClass", "field1", MemberType.FIELD, false)));
 


### PR DESCRIPTION
This PR refactors the plugin report output logic to align with Maven goal terminology—changing generated filenames from `*-mojo.html` to `*-goal.html`.

**Scope of changes:**
- Updated output filename logic in `PluginReport.java` and `PluginOverviewRenderer.java`
- Adjusted integration test assertions across multiple `verify.groovy` files
- Revised `.apt` site templates to reflect new goal-based naming
- Ensured legacy references to "Mojo" remain where conceptually relevant

**Verification:**
- Ran `mvn verify` successfully
- Ran integration tests via `mvn -Prun-its verify` with all checks passing

Closes #949  
Contributed as part of Hacktoberfest 🎉

---

✅ I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
