### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -79,7 +79,6 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -87,6 +86,8 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JavaMojoDescriptorExtractor, a MojoDescriptor extractor to read descriptors from java classes with annotations.
@@ -97,7 +98,8 @@ import org.objectweb.asm.Opcodes;
  */
 @Named(JavaAnnotationsMojoDescriptorExtractor.NAME)
 @Singleton
-public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled implements MojoDescriptorExtractor {
+public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExtractor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaAnnotationsMojoDescriptorExtractor.class);
     public static final String NAME = "java-annotations";
 
     private static final GroupKey GROUP_KEY = new GroupKey(GroupKey.JAVA_GROUP, 100);
@@ -451,7 +453,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            getLogger().warn("Failed extracting tag '" + tagName + "' from class " + str);
+            LOGGER.warn("Failed extracting tag '" + tagName + "' from class " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -491,7 +493,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
 
             return rawParams;
         } catch (NoClassDefFoundError e) {
-            getLogger().warn("Failed extracting parameters from " + javaClass);
+            LOGGER.warn("Failed extracting parameters from " + javaClass);
             throw e;
         }
     }
@@ -543,7 +545,7 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (Throwable t) {
                 str = javaClass.getValue();
             }
-            getLogger().warn("Failed extracting methods from " + str);
+            LOGGER.warn("Failed extracting methods from " + str);
             throw (NoClassDefFoundError) new NoClassDefFoundError(e.getMessage()).initCause(e);
         }
     }
@@ -592,10 +594,10 @@ public class JavaAnnotationsMojoDescriptorExtractor extends AbstractLogEnabled i
             } catch (ArtifactResolutionException e) {
                 String message = "Unable to get sources artifact for " + artifact.getId()
                         + ". Some javadoc tags (@since, @deprecated and comments) won't be used";
-                if (getLogger().isDebugEnabled()) {
-                    getLogger().warn(message, e);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.warn(message, e);
                 } else {
-                    getLogger().warn(message);
+                    LOGGER.warn(message);
                 }
                 return;
             }

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
@@ -49,13 +49,14 @@ import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.Mojo
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoClassVisitor;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoFieldVisitor;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors.MojoParameterVisitor;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.reflection.Reflector;
 import org.codehaus.plexus.util.reflection.ReflectorException;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Mojo scanner with java annotations.
@@ -65,7 +66,8 @@ import org.objectweb.asm.Type;
  */
 @Named
 @Singleton
-public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements MojoAnnotationsScanner {
+public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMojoAnnotationsScanner.class);
     public static final String MVN4_API = "org.apache.maven.api.plugin.annotations.";
     public static final String MOJO_V4 = MVN4_API + "Mojo";
     public static final String EXECUTE_V4 = MVN4_API + "Execute";
@@ -166,7 +168,7 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
             }
         } catch (IllegalArgumentException e) {
             // In case of a class with newer specs an IllegalArgumentException can be thrown
-            getLogger().error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
+            LOGGER.error("Failed to analyze " + archiveFile.getAbsolutePath() + "!/" + zipEntryName);
 
             throw e;
         }
@@ -224,17 +226,15 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
             ClassReader rdr = new ClassReader(is);
             rdr.accept(mojoClassVisitor, ClassReader.SKIP_FRAMES | ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
         } catch (ArrayIndexOutOfBoundsException aiooe) {
-            getLogger()
-                    .warn(
-                            "Error analyzing class " + file + " in " + source + ": ignoring class",
-                            getLogger().isDebugEnabled() ? aiooe : null);
+            LOGGER.warn(
+                    "Error analyzing class " + file + " in " + source + ": ignoring class",
+                    LOGGER.isDebugEnabled() ? aiooe : null);
             return;
         } catch (IllegalArgumentException iae) {
             if (iae.getMessage() == null) {
-                getLogger()
-                        .warn(
-                                "Error analyzing class " + file + " in " + source + ": ignoring class",
-                                getLogger().isDebugEnabled() ? iae : null);
+                LOGGER.warn(
+                        "Error analyzing class " + file + " in " + source + ": ignoring class",
+                        LOGGER.isDebugEnabled() ? iae : null);
                 return;
             } else {
                 throw iae;
@@ -251,10 +251,9 @@ public class DefaultMojoAnnotationsScanner extends AbstractLogEnabled implements
 
         if (mojoAnnotatedClass != null) // see MPLUGIN-206 we can have intermediate classes without annotations
         {
-            if (getLogger().isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
-                getLogger()
-                        .debug("found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":"
-                                + mojoAnnotatedClass);
+            if (LOGGER.isDebugEnabled() && mojoAnnotatedClass.hasAnnotations()) {
+                LOGGER.debug(
+                        "found MojoAnnotatedClass:" + mojoAnnotatedClass.getClassName() + ":" + mojoAnnotatedClass);
             }
             mojoAnnotatedClass.setArtifact(artifact);
             mojoAnnotatedClasses.put(mojoAnnotatedClass.getClassName(), mojoAnnotatedClass);

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractorTest.java
@@ -35,13 +35,11 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.DefaultPluginToolsRequest;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner;
-import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class JavaAnnotationsMojoDescriptorExtractorTest {
     @TempDir
@@ -55,7 +53,6 @@ class JavaAnnotationsMojoDescriptorExtractorTest {
         Files.copy(sourceClass, targetDir.resolve(sourceClass.getFileName()));
         JavaAnnotationsMojoDescriptorExtractor mojoDescriptorExtractor = new JavaAnnotationsMojoDescriptorExtractor();
         DefaultMojoAnnotationsScanner scanner = new DefaultMojoAnnotationsScanner();
-        scanner.enableLogging(mock(Logger.class));
         mojoDescriptorExtractor.mojoAnnotationsScanner = scanner;
         PluginDescriptor pluginDescriptor = new PluginDescriptor();
         MavenProject mavenProject = new MavenProject();

--- a/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
+++ b/maven-plugin-tools-annotations/src/test/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScannerTest.java
@@ -37,7 +37,6 @@ import org.apache.maven.tools.plugin.extractor.annotations.FooMojo;
 import org.apache.maven.tools.plugin.extractor.annotations.ParametersWithGenericsMojo;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ParameterAnnotationContent;
-import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 class DefaultMojoAnnotationsScannerTest {
     private DefaultMojoAnnotationsScanner scanner = new DefaultMojoAnnotationsScanner();
@@ -58,7 +56,6 @@ class DefaultMojoAnnotationsScannerTest {
 
     @Test
     void testJava8Annotations() throws Exception {
-        scanner.enableLogging(mock(Logger.class));
         scanner.scanArchive(new File("target/test-classes/java8-annotations.jar"), null, false);
     }
 
@@ -66,7 +63,6 @@ class DefaultMojoAnnotationsScannerTest {
     void scanDeprecatedMojoAnnotatins() throws ExtractionException, IOException {
         File directoryToScan = new File(DeprecatedMojo.class.getResource("").getFile());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> result =
                 scanner.scanDirectory(directoryToScan, Collections.singletonList("DeprecatedMojo.class"), null, false);
 
@@ -94,7 +90,6 @@ class DefaultMojoAnnotationsScannerTest {
         File directoryToScan =
                 new File(ParametersWithGenericsMojo.class.getResource("").getFile());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> result = scanner.scanDirectory(
                 directoryToScan, Collections.singletonList("ParametersWithGenericsMojo**.class"), null, false);
 
@@ -141,7 +136,6 @@ class DefaultMojoAnnotationsScannerTest {
         request.setIncludePatterns(Arrays.asList("**/FooMojo.class"));
         request.setProject(new MavenProject());
 
-        scanner.enableLogging(mock(Logger.class));
         Map<String, MojoAnnotatedClass> mojoAnnotatedClasses = scanner.scan(request);
 
         System.out.println("mojoAnnotatedClasses:" + mojoAnnotatedClasses);

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/extractor/AbstractScriptedMojoDescriptorExtractor.java
@@ -30,17 +30,19 @@ import org.apache.maven.plugin.descriptor.InvalidPluginDescriptorException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @deprecated Scripting support for Mojos is deprecated and is planned to be removed in Maven 4.0
  * @author jdcasey
  */
 @Deprecated
-public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLogEnabled
-        implements MojoDescriptorExtractor {
+public abstract class AbstractScriptedMojoDescriptorExtractor implements MojoDescriptorExtractor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractScriptedMojoDescriptorExtractor.class);
+
     @Override
     public boolean isDeprecated() {
         return true;
@@ -50,7 +52,7 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
     @Override
     public List<MojoDescriptor> execute(PluginToolsRequest request)
             throws ExtractionException, InvalidPluginDescriptorException {
-        getLogger().debug("Running: " + getClass().getName());
+        LOGGER.debug("Running: " + getClass().getName());
         String metadataExtension = getMetadataFileExtension(request);
         String scriptExtension = getScriptFileExtension(request);
 
@@ -75,8 +77,8 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
                 scriptFilesKeyedByBasedir, project.getBuild().getOutputDirectory(), request);
 
         if (!mojoDescriptors.isEmpty()) {
-            getLogger().warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
-            getLogger().warn("Found " + mojoDescriptors.size() + " scripted mojos.");
+            LOGGER.warn("Scripting support for mojos is deprecated and is planned to be removed in Maven 4.");
+            LOGGER.warn("Found " + mojoDescriptors.size() + " scripted mojos.");
         }
 
         return mojoDescriptors;
@@ -140,9 +142,8 @@ public abstract class AbstractScriptedMojoDescriptorExtractor extends AbstractLo
         for (String resourceDir : directories) {
             Set<File> sources = new HashSet<>();
 
-            getLogger()
-                    .debug("Scanning script dir: " + resourceDir + " with extractor: "
-                            + getClass().getName());
+            LOGGER.debug("Scanning script dir: " + resourceDir + " with extractor: "
+                    + getClass().getName());
             File dir = new File(resourceDir);
             if (!dir.isAbsolute()) {
                 dir = new File(basedir, resourceDir).getAbsoluteFile();

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginHelpGenerator.java
@@ -28,9 +28,6 @@ import java.io.Writer;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.velocity.VelocityContext;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.codehaus.plexus.velocity.VelocityComponent;
 
@@ -44,7 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 2.4
  */
-public class PluginHelpGenerator extends AbstractLogEnabled {
+public class PluginHelpGenerator {
     /**
      * Default generated class name
      */
@@ -60,7 +57,7 @@ public class PluginHelpGenerator extends AbstractLogEnabled {
      * Default constructor
      */
     public PluginHelpGenerator() {
-        this.enableLogging(new ConsoleLogger(Logger.LEVEL_INFO, "PluginHelpGenerator"));
+        // nop
     }
 
     // ----------------------------------------------------------------------

--- a/maven-plugin-tools-java/src/main/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaJavadocMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-java/src/main/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaJavadocMojoDescriptorExtractor.java
@@ -49,7 +49,8 @@ import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.extractor.GroupKey;
 import org.apache.maven.tools.plugin.extractor.MojoDescriptorExtractor;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -65,9 +66,10 @@ import org.codehaus.plexus.logging.AbstractLogEnabled;
  */
 @Named(JavaJavadocMojoDescriptorExtractor.NAME)
 @Singleton
-public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
-        implements MojoDescriptorExtractor, JavadocMojoAnnotation {
+public class JavaJavadocMojoDescriptorExtractor implements MojoDescriptorExtractor, JavadocMojoAnnotation {
     public static final String NAME = "java-javadoc";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaJavadocMojoDescriptorExtractor.class);
 
     private static final GroupKey GROUP_KEY = new GroupKey(GroupKey.JAVA_GROUP, 200);
 
@@ -191,10 +193,10 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
         // executionStrategy (and deprecated @attainAlways)
         tag = findInClassHierarchy(javaClass, JavadocMojoAnnotation.MULTI_EXECUTION_STRATEGY);
         if (tag != null) {
-            getLogger()
-                    .warn("@" + JavadocMojoAnnotation.MULTI_EXECUTION_STRATEGY + " in "
-                            + javaClass.getFullyQualifiedName() + " is deprecated: please use '@"
-                            + JavadocMojoAnnotation.EXECUTION_STATEGY + " always' instead.");
+            LOGGER.warn(
+                    "@" + JavadocMojoAnnotation.MULTI_EXECUTION_STRATEGY + " in {} is deprecated: please use '@"
+                            + JavadocMojoAnnotation.EXECUTION_STATEGY + " always' instead.",
+                    javaClass.getFullyQualifiedName());
             mojoDescriptor.setExecutionStrategy(MojoDescriptor.MULTI_PASS_EXEC_STRATEGY);
         } else {
             mojoDescriptor.setExecutionStrategy(MojoDescriptor.SINGLE_PASS_EXEC_STRATEGY);
@@ -424,12 +426,12 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
                 String property = parameter.getNamedParameter(JavadocMojoAnnotation.PARAMETER_PROPERTY);
 
                 if ((expression != null && !expression.isEmpty()) && (property != null && !property.isEmpty())) {
-                    getLogger().error(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
-                    getLogger().error("  Cannot use both:");
-                    getLogger().error("    @parameter expression=\"${property}\"");
-                    getLogger().error("  and");
-                    getLogger().error("    @parameter property=\"property\"");
-                    getLogger().error("  Second syntax is preferred.");
+                    LOGGER.error(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
+                    LOGGER.error("  Cannot use both:");
+                    LOGGER.error("    @parameter expression=\"${property}\"");
+                    LOGGER.error("  and");
+                    LOGGER.error("    @parameter property=\"property\"");
+                    LOGGER.error("  Second syntax is preferred.");
                     throw new InvalidParameterException(
                             javaClass.getFullyQualifiedName() + "#" + field.getName() + ": cannot"
                                     + " use both @parameter expression and property",
@@ -437,12 +439,12 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
                 }
 
                 if (expression != null && !expression.isEmpty()) {
-                    getLogger().warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
-                    getLogger().warn("  The syntax");
-                    getLogger().warn("    @parameter expression=\"${property}\"");
-                    getLogger().warn("  is deprecated, please use");
-                    getLogger().warn("    @parameter property=\"property\"");
-                    getLogger().warn("  instead.");
+                    LOGGER.warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
+                    LOGGER.warn("  The syntax");
+                    LOGGER.warn("    @parameter expression=\"${property}\"");
+                    LOGGER.warn("  is deprecated, please use");
+                    LOGGER.warn("    @parameter property=\"property\"");
+                    LOGGER.warn("  instead.");
 
                 } else if (property != null && !property.isEmpty()) {
                     expression = "${" + property + "}";
@@ -451,12 +453,12 @@ public class JavaJavadocMojoDescriptorExtractor extends AbstractLogEnabled
                 pd.setExpression(expression);
 
                 if ((expression != null && !expression.isEmpty()) && expression.startsWith("${component.")) {
-                    getLogger().warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
-                    getLogger().warn("  The syntax");
-                    getLogger().warn("    @parameter expression=\"${component.<role>#<roleHint>}\"");
-                    getLogger().warn("  is deprecated, please use");
-                    getLogger().warn("    @component role=\"<role>\" roleHint=\"<roleHint>\"");
-                    getLogger().warn("  instead.");
+                    LOGGER.warn(javaClass.getFullyQualifiedName() + "#" + field.getName() + ":");
+                    LOGGER.warn("  The syntax");
+                    LOGGER.warn("    @parameter expression=\"${component.<role>#<roleHint>}\"");
+                    LOGGER.warn("  is deprecated, please use");
+                    LOGGER.warn("    @component role=\"<role>\" roleHint=\"<roleHint>\"");
+                    LOGGER.warn("  instead.");
                 }
 
                 if ("${reports}".equals(pd.getExpression())) {

--- a/maven-plugin-tools-java/src/test/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaMojoDescriptorExtractorTest.java
+++ b/maven-plugin-tools-java/src/test/java/org/apache/maven/tools/plugin/extractor/javadoc/JavaMojoDescriptorExtractorTest.java
@@ -35,8 +35,6 @@ import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.apache.maven.tools.plugin.generator.Generator;
 import org.apache.maven.tools.plugin.generator.PluginDescriptorFilesGenerator;
 import org.apache.maven.tools.plugin.util.PluginUtils;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.FileUtils;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -96,7 +94,6 @@ public class JavaMojoDescriptorExtractorTest {
      */
     protected PluginDescriptor generate(String directory) throws Exception {
         JavaJavadocMojoDescriptorExtractor extractor = new JavaJavadocMojoDescriptorExtractor();
-        extractor.enableLogging(new ConsoleLogger(Logger.LEVEL_INFO, "test"));
         PluginToolsRequest request = createRequest(directory);
 
         List<MojoDescriptor> mojoDescriptors = extractor.execute(request);


### PR DESCRIPTION
* refactor: Replace Plexus AbstractLogEnabled with SLF4J

Use this link to re-run the recipe: https://app.moderne.io/builder/P4zH7djn6?organizationId=QXBhY2hlIE1hdmVu

* Remove calls to `enableLogging` and retain original logger name for scanner

* Apply formatter and fix checkstyle violations

* Fix more checkstyle violations

* Apply for JavaJavadocMojoDescriptorExtractor

---------


(cherry picked from commit 301bc33e90cc7b4013edbb793b9d7cffcc925be1)

- https://github.com/apache/maven-plugin-tools/pull/343