### PR TITLE
Add support for Maven 4 PluginDescriptor.getRequiredJavaVersion() method

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -42,7 +42,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.DefaultPluginToolsRequest;
-import org.apache.maven.tools.plugin.ExtendedPluginDescriptor;
+import org.apache.maven.tools.plugin.PluginDescriptorHelper;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
 import org.apache.maven.tools.plugin.generator.GeneratorException;
@@ -376,10 +376,9 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
     }
 
     private PluginDescriptor extendPluginDescriptor(PluginToolsRequest request) {
-        ExtendedPluginDescriptor extendedPluginDescriptor = new ExtendedPluginDescriptor(request.getPluginDescriptor());
-        extendedPluginDescriptor.setRequiredJavaVersion(getRequiredJavaVersion(request));
-        extendedPluginDescriptor.setRequiredMavenVersion(getRequiredMavenVersion(request));
-        return extendedPluginDescriptor;
+        PluginDescriptor pluginDescriptor = request.getPluginDescriptor();
+        pluginDescriptor.setRequiredMavenVersion(getRequiredMavenVersion(request));
+        return PluginDescriptorHelper.setRequiredJavaVersion(pluginDescriptor, getRequiredJavaVersion(request));
     }
 
     private String getRequiredMavenVersion(PluginToolsRequest request) {

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/RequirementsHistory.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/RequirementsHistory.java
@@ -29,7 +29,7 @@ import org.apache.maven.model.PluginContainer;
 import org.apache.maven.model.Prerequisites;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.tools.plugin.ExtendedPluginDescriptor;
+import org.apache.maven.tools.plugin.PluginDescriptorHelper;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
@@ -114,11 +114,7 @@ public class RequirementsHistory {
      * @return the JDK version
      */
     public static String discoverJdkRequirement(MavenProject project, PluginDescriptor pluginDescriptor) {
-        String jdk = null;
-        if (pluginDescriptor instanceof ExtendedPluginDescriptor) {
-            ExtendedPluginDescriptor extPluginDescriptor = (ExtendedPluginDescriptor) pluginDescriptor;
-            jdk = extPluginDescriptor.getRequiredJavaVersion();
-        }
+        String jdk = PluginDescriptorHelper.getRequiredJavaVersion(pluginDescriptor);
         if (jdk != null) {
             return jdk;
         }

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/PluginDescriptorHelper.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/PluginDescriptorHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.tools.plugin;
+
+import java.lang.reflect.Method;
+
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+
+public class PluginDescriptorHelper {
+
+    private static final Method GET_REQUIRED_JAVA_VERSION_METHOD;
+    private static final Method SET_REQUIRED_JAVA_VERSION_METHOD;
+
+    static {
+        Method getMethod = null;
+        Method setMethod = null;
+        try {
+            getMethod = PluginDescriptor.class.getMethod("getRequiredJavaVersion");
+            setMethod = PluginDescriptor.class.getMethod("setRequiredJavaVersion", String.class);
+        } catch (NoSuchMethodException e) {
+            // Methods don't exist in this version of Maven
+        }
+        GET_REQUIRED_JAVA_VERSION_METHOD = getMethod;
+        SET_REQUIRED_JAVA_VERSION_METHOD = setMethod;
+    }
+
+    public static String getRequiredJavaVersion(PluginDescriptor descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+
+        // First try to use the direct method if available in Maven 4
+        if (GET_REQUIRED_JAVA_VERSION_METHOD != null) {
+            try {
+                return (String) GET_REQUIRED_JAVA_VERSION_METHOD.invoke(descriptor);
+            } catch (Exception e) {
+                // Fall back to the wrapper approach
+            }
+        }
+
+        // Fall back to the wrapper approach for Maven 3
+        if (descriptor instanceof ExtendedPluginDescriptor) {
+            return ((ExtendedPluginDescriptor) descriptor).getRequiredJavaVersion();
+        }
+
+        return null;
+    }
+
+    /**
+     * Sets the required Java version on a plugin descriptor.
+     * <p>
+     * This method works with both Maven 3 and Maven 4:
+     * <ul>
+     *   <li>In Maven 4, it uses the direct method on the PluginDescriptor class</li>
+     *   <li>In Maven 3, it uses the ExtendedPluginDescriptor wrapper</li>
+     * </ul>
+     *
+     * @param descriptor the plugin descriptor
+     * @param requiredJavaVersion the required Java version to set
+     * @return the modified plugin descriptor, or null if the input descriptor was null
+     */
+    public static PluginDescriptor setRequiredJavaVersion(PluginDescriptor descriptor, String requiredJavaVersion) {
+        if (descriptor == null) {
+            return null;
+        }
+
+        // First try to use the direct method if available in Maven 4
+        if (SET_REQUIRED_JAVA_VERSION_METHOD != null) {
+            try {
+                SET_REQUIRED_JAVA_VERSION_METHOD.invoke(descriptor, requiredJavaVersion);
+                return descriptor;
+            } catch (Exception e) {
+                // Fall back to the wrapper approach
+            }
+        }
+
+        // Fall back to the wrapper approach for Maven 3
+        if (!(descriptor instanceof ExtendedPluginDescriptor)) {
+            descriptor = new ExtendedPluginDescriptor(descriptor);
+        }
+        ((ExtendedPluginDescriptor) descriptor).setRequiredJavaVersion(requiredJavaVersion);
+        return descriptor;
+    }
+}

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
@@ -35,7 +35,7 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.descriptor.Requirement;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.tools.plugin.ExtendedMojoDescriptor;
-import org.apache.maven.tools.plugin.ExtendedPluginDescriptor;
+import org.apache.maven.tools.plugin.PluginDescriptorHelper;
 import org.apache.maven.tools.plugin.PluginToolsRequest;
 import org.apache.maven.tools.plugin.javadoc.JavadocLinkGenerator;
 import org.apache.maven.tools.plugin.util.PluginUtils;
@@ -58,7 +58,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * </ol>
  * from a given in-memory descriptor. The in-memory descriptor acting as source is supposed to contain XHTML values
  * for description elements.
- *
  */
 public class PluginDescriptorFilesGenerator implements Generator {
     private static final Logger LOG = LoggerFactory.getLogger(PluginDescriptorFilesGenerator.class);
@@ -147,11 +146,9 @@ public class PluginDescriptorFilesGenerator implements Generator {
                 GeneratorUtils.element(
                         w, "inheritedByDefault", String.valueOf(pluginDescriptor.isInheritedByDefault()));
 
-                if (pluginDescriptor instanceof ExtendedPluginDescriptor) {
-                    ExtendedPluginDescriptor extPluginDescriptor = (ExtendedPluginDescriptor) pluginDescriptor;
-                    if (StringUtils.isNotBlank(extPluginDescriptor.getRequiredJavaVersion())) {
-                        GeneratorUtils.element(w, "requiredJavaVersion", extPluginDescriptor.getRequiredJavaVersion());
-                    }
+                if (StringUtils.isNotBlank(PluginDescriptorHelper.getRequiredJavaVersion(pluginDescriptor))) {
+                    GeneratorUtils.element(
+                            w, "requiredJavaVersion", PluginDescriptorHelper.getRequiredJavaVersion(pluginDescriptor));
                 }
                 if (StringUtils.isNotBlank(pluginDescriptor.getRequiredMavenVersion())) {
                     GeneratorUtils.element(w, "requiredMavenVersion", pluginDescriptor.getRequiredMavenVersion());
@@ -195,7 +192,6 @@ public class PluginDescriptorFilesGenerator implements Generator {
     }
 
     /**
-     *
      * @param type
      * @param containsXhtmlValue
      * @param text
@@ -585,6 +581,7 @@ public class PluginDescriptorFilesGenerator implements Generator {
 
     /**
      * Writes parameter type information and potentially also the related javadoc URL.
+     *
      * @param w
      * @param type
      * @param javadocLinkGenerator


### PR DESCRIPTION
* Add support for Maven 4 PluginDescriptor.getRequiredJavaVersion() method

This commit enhances the PluginDescriptorHelper class to support the getRequiredJavaVersion() and setRequiredJavaVersion() methods directly on the PluginDescriptor class in Maven 4.

The implementation:
1. Uses reflection to check if the methods exist in the current Maven version
2. Tries to use the direct methods first if available (Maven 4)
3. Falls back to the existing wrapper approach if needed (Maven 3)

This approach ensures backward compatibility while taking advantage of the new methods in Maven 4.

* Add missing files

(cherry picked from commit b9393905ec66824d89b5fdfce22246dee9fe0a77)

- #401