### PR TITLE
Fix UWF_NULL_FIELD in DescriptorGeneratorMojo by initializing mojoDependencies

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -196,7 +197,7 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
      * @since 3.5
      */
     @Parameter
-    private List<String> mojoDependencies = null;
+    private final List<String> mojoDependencies = new ArrayList<>();
 
     /**
      * Creates links to existing external javadoc-generated documentation.


### PR DESCRIPTION
This PR fixes a UWF_NULL_FIELD warning reported by SpotBugs in org.apache.maven.plugin.plugin.DescriptorGeneratorMojo.

The field mojoDependencies was declared but never initialized, which left it in a null state.
It is now initialized as an empty ArrayList, removing the null-only assignment and improving robustness.

After this change, the UWF_NULL_FIELD warning is no longer reported for this class
(maven-plugin-plugin module builds successfully and SpotBugs reports are clean for this issue).