### PR TITLE
Check mkdirs() return value when creating output directory in DescriptorGeneratorMojo

### DIFF
--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -373,7 +373,12 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
             mojoScanner.populatePluginDescriptor(request);
             request.setPluginDescriptor(extendPluginDescriptor(request));
 
-            outputDirectory.mkdirs();
+            if (!outputDirectory.exists()) {
+                if (!outputDirectory.mkdirs()) {
+                    throw new MojoExecutionException(
+                            "Could not create output directory: " + outputDirectory.getAbsolutePath());
+                }
+            }
 
             PluginDescriptorFilesGenerator pluginDescriptorGenerator = new PluginDescriptorFilesGenerator();
             pluginDescriptorGenerator.execute(outputDirectory, request);


### PR DESCRIPTION
This PR addresses a RV_RETURN_VALUE_IGNORED_BAD_PRACTICE warning reported by SpotBugs in
org.apache.maven.plugin.plugin.DescriptorGeneratorMojo.generate().

The call to java.io.File.mkdirs() previously ignored its boolean return value.
The code now:

Checks whether the output directory already exists.

Calls mkdirs() only when necessary.

Throws a MojoExecutionException when directory creation fails, instead of silently ignoring the error.

After this change, the RV warning no longer appears in the SpotBugs report for this class.