### PR TITLE
JavadocLinkGenerator.createLink(String) must consider module names

### DIFF
--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocLinkGenerator.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocLinkGenerator.java
@@ -112,7 +112,7 @@ public class JavadocLinkGenerator {
             // resolve version
             JavaVersion javadocVersion = JavaVersion.parse(internalJavadocVersion);
             internalJavadocSite =
-                    new JavadocSite(internalJavadocSiteUrl, JavadocToolVersionRange.findMatch(javadocVersion), false);
+                    new JavadocSite(internalJavadocSiteUrl, JavadocToolVersionRange.findMatch(javadocVersion));
         } else {
             internalJavadocSite = null;
         }
@@ -140,7 +140,7 @@ public class JavadocLinkGenerator {
      * Only uses the offline site for references returning {@code false} for
      * {@link FullyQualifiedJavadocReference#isExternal()}.
      * @param javadocReference
-     * @return the (deep-) link towards a javadoc page
+     * @return the (deep-)link to a javadoc page
      * @throws IllegalArgumentException in case no javadoc link could be generated for the given reference
      * @throws IllegalStateException in case no javadoc source sites have been configured
      */
@@ -163,7 +163,7 @@ public class JavadocLinkGenerator {
      * Preferably resolves from the online sites if they provide the given package.
      * @param binaryName a binary name according to
      * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">JLS 13.1</a>
-     * @return the (deep-) link towards a javadoc page
+     * @return the (deep-)link to a javadoc page
      * @throws IllegalArgumentException in case no javadoc link could be generated for the given name
      */
     public URI createLink(String binaryName) {

--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocNonLtsSiteIT.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocNonLtsSiteIT.java
@@ -72,4 +72,11 @@ class JavadocNonLtsSiteIT extends JavadocSiteIT {
     void nestedClass(URI javadocBaseUrl) throws Exception {
         super.nestedClass(javadocBaseUrl);
     }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("javadocBaseUrls")
+    void clazz(URI javadocBaseUrl) throws Exception {
+        super.clazz(javadocBaseUrl);
+    }
 }

--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteIT.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteIT.java
@@ -21,6 +21,7 @@ package org.apache.maven.tools.plugin.javadoc;
 import java.net.URI;
 import java.util.stream.Stream;
 
+import org.apache.maven.settings.Settings;
 import org.apache.maven.tools.plugin.javadoc.FullyQualifiedJavadocReference.MemberType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -39,7 +40,7 @@ class JavadocSiteIT {
     @ParameterizedTest
     @MethodSource("javadocBaseUrls")
     void constructors(URI javadocBaseUrl) throws Exception {
-        JavadocSite site = new JavadocSite(javadocBaseUrl, null);
+        JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
         JavadocSiteTest.assertUrlValid(site.createLink(new FullyQualifiedJavadocReference(
                 "java.lang", "String", "String(byte[],int)", MemberType.CONSTRUCTOR, true)));
     }
@@ -47,7 +48,7 @@ class JavadocSiteIT {
     @ParameterizedTest
     @MethodSource("javadocBaseUrls")
     void methods(URI javadocBaseUrl) throws Exception {
-        JavadocSite site = new JavadocSite(javadocBaseUrl, null);
+        JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
         JavadocSiteTest.assertUrlValid(site.createLink(new FullyQualifiedJavadocReference(
                 "java.lang", "String", "copyValueOf(char[],int,int)", MemberType.METHOD, true)));
     }
@@ -55,7 +56,7 @@ class JavadocSiteIT {
     @ParameterizedTest
     @MethodSource("javadocBaseUrls")
     void fields(URI javadocBaseUrl) throws Exception {
-        JavadocSite site = new JavadocSite(javadocBaseUrl, null);
+        JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
         JavadocSiteTest.assertUrlValid(site.createLink(new FullyQualifiedJavadocReference(
                 "java.lang", "String", "CASE_INSENSITIVE_ORDER", MemberType.FIELD, true)));
     }
@@ -63,8 +64,15 @@ class JavadocSiteIT {
     @ParameterizedTest
     @MethodSource("javadocBaseUrls")
     void nestedClass(URI javadocBaseUrl) throws Exception {
-        JavadocSite site = new JavadocSite(javadocBaseUrl, null);
+        JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
         JavadocSiteTest.assertUrlValid(
                 site.createLink(new FullyQualifiedJavadocReference("java.util", "Map.Entry", true)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("javadocBaseUrls")
+    void clazz(URI javadocBaseUrl) throws Exception {
+        JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
+        JavadocSiteTest.assertUrlValid(site.createLink("java.lang", "String"));
     }
 }

--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -111,6 +112,17 @@ class JavadocSiteTest {
     }
 
     @Test
+    void classLinkFromPackageAndClassNameWithExternalJavadocRequiringModules() throws URISyntaxException, IOException {
+        URI baseUri = new URI("https://docs.oracle.com/en/java/javase/11/docs/api/");
+        JavadocSite site = new JavadocSite(
+                baseUri,
+                JavadocLinkGenerator.JavadocToolVersionRange.JDK10_OR_HIGHER,
+                Collections.singletonMap("java.lang", "java.base"));
+        // don't request URL to make test independent of network connectivity
+        assertEquals(baseUri.resolve("java.base/java/lang/String.html"), site.createLink("java.lang", "String"));
+    }
+
+    @Test
     void getPackageAndClassName() {
         assertEquals(
                 new AbstractMap.SimpleEntry<>("java.util", "Map"),
@@ -137,7 +149,7 @@ class JavadocSiteTest {
             throws URISyntaxException {
         URI javadocBaseUri =
                 JavadocSiteTest.class.getResource("/javadoc/" + name + "/").toURI();
-        return new JavadocSite(javadocBaseUri, version, false);
+        return new JavadocSite(javadocBaseUri, version);
     }
 
     static void assertUrlValid(final URI url) {


### PR DESCRIPTION
When link towards external javadoc with modules generated include the module name in the URL path

This closes #1038

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
