### PR TITLE
Fix NPE in EnhancedPluginDescriptorBuilder with Maven 4

### DIFF
--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/EnhancedPluginDescriptorBuilder.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/EnhancedPluginDescriptorBuilder.java
@@ -70,10 +70,18 @@ public class EnhancedPluginDescriptorBuilder extends PluginDescriptorBuilder {
         PluginDescriptor pluginDescriptor = super.build(reader, source);
         // elements added in plugin descriptor 1.1
         ExtendedPluginDescriptor extendedPluginDescriptor = new ExtendedPluginDescriptor(pluginDescriptor);
-        extendedPluginDescriptor.setRequiredJavaVersion(
-                configuration.getChild("requiredJavaVersion").getValue());
-        extendedPluginDescriptor.setRequiredMavenVersion(
-                configuration.getChild("requiredMavenVersion").getValue());
+        if (configuration != null) {
+            // Maven 3.x path: buildConfiguration() was called by super.build(), so configuration is available
+            extendedPluginDescriptor.setRequiredJavaVersion(
+                    configuration.getChild("requiredJavaVersion").getValue());
+            extendedPluginDescriptor.setRequiredMavenVersion(
+                    configuration.getChild("requiredMavenVersion").getValue());
+        } else {
+            // Maven 4+ path: PluginDescriptorBuilder no longer calls buildConfiguration(),
+            // but already populates requiredJavaVersion/requiredMavenVersion on the descriptor
+            extendedPluginDescriptor.setRequiredJavaVersion(pluginDescriptor.getRequiredJavaVersion());
+            // requiredMavenVersion is already accessible through ExtendedPluginDescriptor's delegation
+        }
         return extendedPluginDescriptor;
     }
 


### PR DESCRIPTION
## Summary

- Fix NPE in `EnhancedPluginDescriptorBuilder.build(Reader, String)` when running under Maven 4
- Maven 4 refactored `PluginDescriptorBuilder.build()` to no longer call `buildConfiguration()`, leaving the `configuration` field null
- When `configuration` is null (Maven 4+), read `requiredJavaVersion`/`requiredMavenVersion` from the `PluginDescriptor` directly, since Maven 4's builder already populates them

Fixes #806

## Context

This is the main blocker for #1091 (enable Maven 4 CI builds). Maven 4 changed `PluginDescriptorBuilder.build(Reader, String)` in [MNG-8084](https://github.com/apache/maven/commit/003a5bc06d) to delegate to a new `build(ReaderSupplier, String)` method that no longer calls the overridable `buildConfiguration()`. The `EnhancedPluginDescriptorBuilder` relied on that callback to capture the raw XML configuration.

## Test plan

- [x] Existing unit tests pass (verified locally)
- [ ] CI with Maven 3.9.14 should pass (no behavior change)
- [ ] CI with Maven 4 should fix the 12 failing reporting ITs

🤖 Generated with [Claude Code](https://claude.com/claude-code)