### PR TITLE
#1105 Modified to properly report expression and defaultValue when processing Maven 4 plugin

### DIFF
--- a/maven-plugin-report-plugin/pom.xml
+++ b/maven-plugin-report-plugin/pom.xml
@@ -261,6 +261,7 @@
               </extraArtifacts>
               <scriptVariables>
                 <maven3Version>${maven3Version}</maven3Version>
+                <maven4Version>${maven4Version}</maven4Version>
               </scriptVariables>
             </configuration>
             <executions>

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/invoker.properties
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean site

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/invoker.properties
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/invoker.properties
@@ -16,3 +16,4 @@
 # under the License.
 
 invoker.goals = clean site
+invoker.java.version = 17+

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/pom.xml
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>plugin-report</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>MPLUGIN-105</name>
+  <description>
+    Test basic site generation to guard against regression.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>@maven4Version@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>@maven4Version@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>@maven4Version@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-api</artifactId>
+      <version>@reportingApiVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-impl</artifactId>
+      <version>@reportingImplVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>@project.version@</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@version.maven-compiler-plugin@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>prefix</goalPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>@sitePluginVersion@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>@projectInfoReportsPlugin@</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
+        <version>@project.version@</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/DummyReport.java
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/DummyReport.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org;
+
+import java.io.File;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.siterenderer.Renderer;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.reporting.AbstractMavenReport;
+import org.apache.maven.reporting.AbstractMavenReportRenderer;
+import org.apache.maven.reporting.MavenReportException;
+
+/**
+ * Dummy Reporting Plugin.
+ */
+@Mojo(name = "report", requiresReports = true)
+@Execute(phase = LifecyclePhase.COMPILE)
+public class DummyReport extends AbstractMavenReport {
+    /**
+     * Report output directory.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-site/xdoc")
+    private File outputDirectory;
+
+    /**
+     * Doxia Site Renderer.
+     */
+    @Component
+    private Renderer siteRenderer;
+
+    /**
+     * The Maven Project.
+     */
+    @Parameter(property = "project", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * The goal prefix that will appear before the ":".
+     *
+     * @since 2.4
+     */
+    @Parameter(property = "goalPrefix")
+    protected String goalPrefix;
+
+    /**
+     * Set this to "true" to skip invoking any goals or reports of the plugin.
+     *
+     * @since 2.8
+     */
+    @Parameter(defaultValue = "false", property = "maven.plugin.skip")
+    private boolean skip;
+
+    /**
+     * Set this to "true" to skip generating the report.
+     *
+     * @since 2.8
+     */
+    @Parameter(defaultValue = "false", property = "maven.plugin.report.skip")
+    private boolean skipReport;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected Renderer getSiteRenderer() {
+        return siteRenderer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getOutputDirectory() {
+        return outputDirectory.getPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected MavenProject getProject() {
+        return project;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean canGenerateReport() {
+        if (skip || skipReport) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected void executeReport(Locale locale) throws MavenReportException {
+        // Generate the plugin's documentation
+        generatePluginDocumentation(locale);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getDescription(Locale locale) {
+        return getBundle(locale).getString("report.plugin.description");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getName(Locale locale) {
+        return getBundle(locale).getString("report.plugin.name");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getOutputName() {
+        return "plugin-info";
+    }
+
+    /**
+     * @param pluginDescriptor not null
+     * @param locale           not null
+     * @throws MavenReportException if any
+     */
+    private void generatePluginDocumentation(Locale locale) throws MavenReportException {
+        File outputDir = new File(getOutputDirectory());
+        outputDir.mkdirs();
+        PluginOverviewRenderer r = new PluginOverviewRenderer(getSink(), locale);
+        r.render();
+    }
+
+    /**
+     * @param locale not null
+     * @return the bundle for this report
+     */
+    protected static ResourceBundle getBundle(Locale locale) {
+        return ResourceBundle.getBundle("plugin-report", locale, DummyReport.class.getClassLoader());
+    }
+
+    /**
+     * Generates an overview page with the list of goals
+     * and a link to the goal's page.
+     */
+    static class PluginOverviewRenderer extends AbstractMavenReportRenderer {
+        private final Locale locale;
+
+        /**
+         * @param sink    not null
+         * @param locale  not null
+         */
+        PluginOverviewRenderer(Sink sink, Locale locale) {
+            super(sink);
+
+            this.locale = locale;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public String getTitle() {
+            return getBundle(locale).getString("report.plugin.title");
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        protected void renderBody() {
+            startSection(getTitle());
+            paragraph("This is a report.");
+            endSection();
+        }
+    }
+}

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/DummyReport.java
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/DummyReport.java
@@ -144,7 +144,6 @@ public class DummyReport extends AbstractMavenReport {
     }
 
     /**
-     * @param pluginDescriptor not null
      * @param locale           not null
      * @throws MavenReportException if any
      */

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/MyMojo.java
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/src/main/java/org/MyMojo.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Does nothing.
+ *
+ * @since 1.0
+ * @deprecated You don't use test goals, do you?
+ */
+@Mojo(
+        name = "noop",
+        defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        requiresDirectInvocation = true,
+        requiresOnline = true,
+        inheritByDefault = false,
+        aggregator = true)
+@Execute(phase = LifecyclePhase.COMPILE)
+public class MyMojo extends AbstractMojo {
+
+    /**
+     * This is a test.
+     */
+    @SuppressWarnings("unused")
+    @Parameter(required = true)
+    private String required;
+
+    /**
+     * This is a test.
+     *
+     * @since 1.1
+     * @deprecated Just testing.
+     */
+    @SuppressWarnings("unused")
+    @Parameter(property = "string", defaultValue = "${project.version}/</markup-must-be-escaped>")
+    private String string;
+
+    public void execute() {
+        // intentional do nothing
+    }
+}

--- a/maven-plugin-report-plugin/src/it/plugin-report-400/verify.groovy
+++ b/maven-plugin-report-plugin/src/it/plugin-report-400/verify.groovy
@@ -26,8 +26,8 @@ assert pluginInfo.isFile()
 assert !pluginInfo.text.contains('Memory')
 assert !pluginInfo.text.contains('Disk Space')
 // check JDK and Maven requirements
-assert pluginInfo.text.contains('1.8')
-assert pluginInfo.text.contains(maven3Version)
+assert pluginInfo.text.contains('2.0.0')
+assert pluginInfo.text.contains(maven4Version)
 
 // deprecated info and description
 assert pluginInfo.text.contains('<div><strong>Deprecated.</strong> You don\'t use test goals, do you?</div><br />')
@@ -44,3 +44,4 @@ def reportMojo = new File( basedir, 'target/site/report-mojo.html' )
 assert reportMojo.isFile()
 
 assert reportMojo.text.contains('<td>Report output directory.<br /><strong>Default</strong>: <code>${project.build.directory}/generated-site/xdoc</code></td>')
+

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/PluginDescriptorBuilder.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/PluginDescriptorBuilder.java
@@ -40,6 +40,9 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
  * @author Jason van Zyl
  */
 public class PluginDescriptorBuilder {
+
+    boolean isV4;
+
     public PluginDescriptor build(Reader reader) throws PlexusConfigurationException {
         return build(reader, null);
     }
@@ -68,6 +71,11 @@ public class PluginDescriptorBuilder {
 
         if (inheritedByDefault != null) {
             pluginDescriptor.setInheritedByDefault(Boolean.parseBoolean(inheritedByDefault));
+        }
+
+        String requiredMavenVersion = c.getChild("requiredMavenVersion").getValue();
+        if (requiredMavenVersion != null) {
+            isV4 = requiredMavenVersion.startsWith("4");
         }
 
         // ----------------------------------------------------------------------
@@ -277,10 +285,15 @@ public class PluginDescriptorBuilder {
 
             parameter.setSince(d.getChild("since").getValue());
 
-            PlexusConfiguration paramConfig = mojoConfig.getChild(parameter.getName(), false);
-            if (paramConfig != null) {
-                parameter.setExpression(paramConfig.getValue(null));
-                parameter.setDefaultValue(paramConfig.getAttribute("default-value"));
+            if (isV4) {
+                parameter.setExpression(d.getChild("expression").getValue());
+                parameter.setDefaultValue(d.getChild("defaultValue").getValue());
+            } else {
+                PlexusConfiguration paramConfig = mojoConfig.getChild(parameter.getName(), false);
+                if (paramConfig != null) {
+                    parameter.setExpression(paramConfig.getValue(null));
+                    parameter.setDefaultValue(paramConfig.getAttribute("default-value"));
+                }
             }
 
             parameters.add(parameter);

--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/PluginDescriptorBuilder.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugins/plugin/descriptor/PluginDescriptorBuilder.java
@@ -41,7 +41,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
  */
 public class PluginDescriptorBuilder {
 
-    boolean isV4;
+    private boolean isV4;
 
     public PluginDescriptor build(Reader reader) throws PlexusConfigurationException {
         return build(reader, null);
@@ -76,6 +76,8 @@ public class PluginDescriptorBuilder {
         String requiredMavenVersion = c.getChild("requiredMavenVersion").getValue();
         if (requiredMavenVersion != null) {
             isV4 = requiredMavenVersion.startsWith("4");
+        } else {
+            isV4 = false;
         }
 
         // ----------------------------------------------------------------------


### PR DESCRIPTION
This includes a change to `PluginDescriptorBuilder` to properly retrieve the the `expression` and `defaultValue` values from the Maven 4 `plugin-enhanced.xml` file when building a plugin for Maven 4. It also includes a new integration test, `plugin-report-400`, to confirm.