### PR TITLE
Wire up @After annotation scanning in the annotation-based descriptor extractor

### DIFF
--- a/maven-plugin-plugin/src/it/v4api-3x/src/main/java/org/apache/maven/its/v4api/FirstMojo.java
+++ b/maven-plugin-plugin/src/it/v4api-3x/src/main/java/org/apache/maven/its/v4api/FirstMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.api.Session;
 import org.apache.maven.api.di.Inject;
 import org.apache.maven.api.plugin.Log;
 import org.apache.maven.api.plugin.MojoException;
+import org.apache.maven.api.plugin.annotations.After;
 import org.apache.maven.api.plugin.annotations.Mojo;
 import org.apache.maven.api.plugin.annotations.Parameter;
 
@@ -38,6 +39,9 @@ import org.apache.maven.api.plugin.annotations.Parameter;
  * @since 1.2
  */
 @Mojo(name = "first", defaultPhase = "integration-test")
+@After(phase = "integration-test")
+@After(phase = "test", type = After.Type.CHILDREN)
+@After(phase = "clean", scope = "runtime", type = After.Type.DEPENDENCIES)
 public class FirstMojo implements org.apache.maven.api.plugin.Mojo {
 
     /**

--- a/maven-plugin-plugin/src/it/v4api-3x/verify.groovy
+++ b/maven-plugin-plugin/src/it/v4api-3x/verify.groovy
@@ -38,6 +38,23 @@ assert mojo.onlineRequired.text() == 'false'
 assert mojo.aggregator.text() == 'false'
 assert mojo.phase.text() == 'integration-test'
 
+assert mojo.afterLinks.afterLink.size() == 3
+
+afterLink = mojo.afterLinks.afterLink.findAll{ it.phase.text() == "integration-test" }[0]
+assert afterLink.phase.text() == 'integration-test'
+assert afterLink.type.isEmpty()
+assert afterLink.scope.isEmpty()
+
+afterLink = mojo.afterLinks.afterLink.findAll{ it.phase.text() == "test" }[0]
+assert afterLink.phase.text() == 'test'
+assert afterLink.type.text() == 'CHILDREN'
+assert afterLink.scope.isEmpty()
+
+afterLink = mojo.afterLinks.afterLink.findAll{ it.phase.text() == "clean" }[0]
+assert afterLink.phase.text() == 'clean'
+assert afterLink.type.text() == 'DEPENDENCIES'
+assert afterLink.scope.text() == 'runtime'
+
 assert mojo.parameters.parameter.size() == 3
 
 parameter = mojo.parameters.parameter.findAll{ it.name.text() == "basedir" }[0]

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -69,6 +69,7 @@ import org.apache.maven.tools.plugin.extractor.annotations.converter.ConverterCo
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavaClassConverterContext;
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavadocBlockTagsToXhtmlConverter;
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavadocInlineTagsToXhtmlConverter;
+import org.apache.maven.tools.plugin.extractor.annotations.datamodel.AfterAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ExecuteAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.MojoAnnotationContent;
@@ -691,6 +692,14 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
                 }
             }
 
+            // @After annotations — collect from class hierarchy
+            List<AfterAnnotationContent> afterAnnotations =
+                    getAfterAnnotationsFromHierarchy(mojoAnnotatedClass, mojoAnnotatedClasses);
+            for (AfterAnnotationContent after : afterAnnotations) {
+                mojoDescriptor.addAfterLink(
+                        new ExtendedMojoDescriptor.AfterLink(after.phase(), after.type(), after.scope()));
+            }
+
             mojoDescriptor.setExecutionStrategy(mojo.executionStrategy());
             // ???
             // mojoDescriptor.alwaysExecute(mojo.a)
@@ -779,6 +788,32 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
             return null;
         }
         return findClassWithExecuteAnnotationInParentHierarchy(parent, mojoAnnotatedClasses);
+    }
+
+    /**
+     * Collects all {@code @After} annotations from the class hierarchy, starting from the
+     * most-derived class.  Unlike {@code @Execute}, {@code @After} is repeatable, so
+     * multiple entries may exist on a single class and across the hierarchy.
+     */
+    protected List<AfterAnnotationContent> getAfterAnnotationsFromHierarchy(
+            MojoAnnotatedClass mojoAnnotatedClass, Map<String, MojoAnnotatedClass> mojoAnnotatedClasses) {
+        List<AfterAnnotationContent> result = new ArrayList<>();
+        collectAfterAnnotations(mojoAnnotatedClass, mojoAnnotatedClasses, result);
+        return result;
+    }
+
+    private void collectAfterAnnotations(
+            MojoAnnotatedClass mojoAnnotatedClass,
+            Map<String, MojoAnnotatedClass> mojoAnnotatedClasses,
+            List<AfterAnnotationContent> result) {
+        result.addAll(mojoAnnotatedClass.getAfterAnnotations());
+        String parentClassName = mojoAnnotatedClass.getParentClassName();
+        if (parentClassName != null && !parentClassName.isEmpty()) {
+            MojoAnnotatedClass parent = mojoAnnotatedClasses.get(parentClassName);
+            if (parent != null) {
+                collectAfterAnnotations(parent, mojoAnnotatedClasses, result);
+            }
+        }
     }
 
     protected Map<String, ParameterAnnotationContent> getParametersParentHierarchy(

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/JavaAnnotationsMojoDescriptorExtractor.java
@@ -67,6 +67,7 @@ import org.apache.maven.tools.plugin.extractor.annotations.converter.ConverterCo
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavaClassConverterContext;
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavadocBlockTagsToXhtmlConverter;
 import org.apache.maven.tools.plugin.extractor.annotations.converter.JavadocInlineTagsToXhtmlConverter;
+import org.apache.maven.tools.plugin.extractor.annotations.datamodel.AfterAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ExecuteAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.MojoAnnotationContent;
@@ -729,6 +730,14 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
                 }
             }
 
+            // @After annotations — collect from class hierarchy
+            List<AfterAnnotationContent> afterAnnotations =
+                    getAfterAnnotationsFromHierarchy(mojoAnnotatedClass, mojoAnnotatedClasses);
+            for (AfterAnnotationContent after : afterAnnotations) {
+                mojoDescriptor.addAfterLink(
+                        new ExtendedMojoDescriptor.AfterLink(after.phase(), after.type(), after.scope()));
+            }
+
             mojoDescriptor.setExecutionStrategy(mojo.executionStrategy());
             // ???
             // mojoDescriptor.alwaysExecute(mojo.a)
@@ -817,6 +826,32 @@ public class JavaAnnotationsMojoDescriptorExtractor implements MojoDescriptorExt
             return null;
         }
         return findClassWithExecuteAnnotationInParentHierarchy(parent, mojoAnnotatedClasses);
+    }
+
+    /**
+     * Collects all {@code @After} annotations from the class hierarchy, starting from the
+     * most-derived class.  Unlike {@code @Execute}, {@code @After} is repeatable, so
+     * multiple entries may exist on a single class and across the hierarchy.
+     */
+    protected List<AfterAnnotationContent> getAfterAnnotationsFromHierarchy(
+            MojoAnnotatedClass mojoAnnotatedClass, Map<String, MojoAnnotatedClass> mojoAnnotatedClasses) {
+        List<AfterAnnotationContent> result = new ArrayList<>();
+        collectAfterAnnotations(mojoAnnotatedClass, mojoAnnotatedClasses, result);
+        return result;
+    }
+
+    private void collectAfterAnnotations(
+            MojoAnnotatedClass mojoAnnotatedClass,
+            Map<String, MojoAnnotatedClass> mojoAnnotatedClasses,
+            List<AfterAnnotationContent> result) {
+        result.addAll(mojoAnnotatedClass.getAfterAnnotations());
+        String parentClassName = mojoAnnotatedClass.getParentClassName();
+        if (parentClassName != null && !parentClassName.isEmpty()) {
+            MojoAnnotatedClass parent = mojoAnnotatedClasses.get(parentClassName);
+            if (parent != null) {
+                collectAfterAnnotations(parent, mojoAnnotatedClasses, result);
+            }
+        }
     }
 
     protected Map<String, ParameterAnnotationContent> getParametersParentHierarchy(

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/datamodel/AfterAnnotationContent.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/datamodel/AfterAnnotationContent.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.tools.plugin.extractor.annotations.datamodel;
+
+/**
+ * Holds scanned data from a {@code @After} annotation
+ * ({@code org.apache.maven.api.plugin.annotations.After}).
+ * <p>
+ * The {@code @After} annotation declares that the annotated mojo must run
+ * after another phase has completed.  It carries three attributes:
+ * <ul>
+ *   <li>{@code phase}  &ndash; the phase this mojo must run after</li>
+ *   <li>{@code type}   &ndash; the scope type ({@code PROJECT}, {@code DEPENDENCIES}, {@code CHILDREN})</li>
+ *   <li>{@code scope}  &ndash; the dependency scope</li>
+ * </ul>
+ * <p>
+ * Setter method names match the annotation attribute names so that
+ * {@link org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner#populateAnnotationContent}
+ * can fill them via reflection.
+ *
+ * @since 4.0.0
+ */
+public class AfterAnnotationContent {
+    private String phase;
+
+    private String type;
+
+    private String scope;
+
+    public String phase() {
+        return this.phase;
+    }
+
+    public void phase(String phase) {
+        this.phase = phase;
+    }
+
+    public String type() {
+        return this.type;
+    }
+
+    public void type(String type) {
+        this.type = type;
+    }
+
+    public String scope() {
+        return this.scope;
+    }
+
+    public void scope(String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("AfterAnnotationContent");
+        sb.append("{phase='").append(phase).append('\'');
+        sb.append(", type='").append(type).append('\'');
+        sb.append(", scope='").append(scope).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/DefaultMojoAnnotationsScanner.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,7 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.tools.plugin.extractor.ExtractionException;
+import org.apache.maven.tools.plugin.extractor.annotations.datamodel.AfterAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ExecuteAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.MojoAnnotationContent;
@@ -73,6 +75,8 @@ public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
     public static final String MOJO_V4 = MVN4_API + "Mojo";
     public static final String EXECUTE_V4 = MVN4_API + "Execute";
     public static final String PARAMETER_V4 = MVN4_API + "Parameter";
+    public static final String AFTER_V4 = MVN4_API + "After";
+    public static final String AFTERS_V4 = MVN4_API + "Afters";
 
     public static final String MOJO_V3 = Mojo.class.getName();
     public static final String EXECUTE_V3 = Execute.class.getName();
@@ -306,6 +310,37 @@ public class DefaultMojoAnnotationsScanner implements MojoAnnotationsScanner {
                 ExecuteAnnotationContent executeAnnotationContent = new ExecuteAnnotationContent();
                 populateAnnotationContent(executeAnnotationContent, mojoAnnotationVisitor);
                 mojoAnnotatedClass.setExecute(executeAnnotationContent);
+            }
+
+            // @After annotation(s) — v4 API only
+            List<AfterAnnotationContent> afterAnnotations = new ArrayList<>();
+
+            // single @After
+            mojoAnnotationVisitor = mojoClassVisitor.getAnnotationVisitor(AFTER_V4);
+            if (mojoAnnotationVisitor != null) {
+                AfterAnnotationContent afterAnnotationContent = new AfterAnnotationContent();
+                populateAnnotationContent(afterAnnotationContent, mojoAnnotationVisitor);
+                afterAnnotations.add(afterAnnotationContent);
+            }
+
+            // @Afters repeatable container wraps multiple @After in its "value" array attribute
+            mojoAnnotationVisitor = mojoClassVisitor.getAnnotationVisitor(AFTERS_V4);
+            if (mojoAnnotationVisitor != null) {
+                // The @Afters annotation has a "value" array attribute; visitArray("value")
+                // creates a sub-visitor, and each nested @After is visited via visitAnnotation
+                // on that sub-visitor.
+                MojoAnnotationVisitor arrayVisitor = mojoAnnotationVisitor.getArrayVisitor("value");
+                if (arrayVisitor != null) {
+                    for (MojoAnnotationVisitor nestedVisitor : arrayVisitor.getNestedAnnotationVisitors()) {
+                        AfterAnnotationContent afterAnnotationContent = new AfterAnnotationContent();
+                        populateAnnotationContent(afterAnnotationContent, nestedVisitor);
+                        afterAnnotations.add(afterAnnotationContent);
+                    }
+                }
+            }
+
+            if (!afterAnnotations.isEmpty()) {
+                mojoAnnotatedClass.setAfterAnnotations(afterAnnotations);
             }
 
             // @Parameter annotations

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/MojoAnnotatedClass.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/MojoAnnotatedClass.java
@@ -18,10 +18,13 @@
  */
 package org.apache.maven.tools.plugin.extractor.annotations.scanner;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.tools.plugin.extractor.annotations.datamodel.AfterAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ComponentAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.ExecuteAnnotationContent;
 import org.apache.maven.tools.plugin.extractor.annotations.datamodel.MojoAnnotationContent;
@@ -41,6 +44,8 @@ public class MojoAnnotatedClass {
     private MojoAnnotationContent mojo;
 
     private ExecuteAnnotationContent execute;
+
+    private List<AfterAnnotationContent> afterAnnotations;
 
     /**
      * key is field name
@@ -99,6 +104,18 @@ public class MojoAnnotatedClass {
         return this;
     }
 
+    public List<AfterAnnotationContent> getAfterAnnotations() {
+        if (this.afterAnnotations == null) {
+            this.afterAnnotations = new ArrayList<>();
+        }
+        return afterAnnotations;
+    }
+
+    public MojoAnnotatedClass setAfterAnnotations(List<AfterAnnotationContent> afterAnnotations) {
+        this.afterAnnotations = afterAnnotations;
+        return this;
+    }
+
     public Map<String, ParameterAnnotationContent> getParameters() {
         if (this.parameters == null) {
             this.parameters = new HashMap<>();
@@ -141,7 +158,11 @@ public class MojoAnnotatedClass {
     }
 
     public boolean hasAnnotations() {
-        return !(getComponents().isEmpty() && getParameters().isEmpty() && execute == null && mojo == null);
+        return !(getComponents().isEmpty()
+                && getParameters().isEmpty()
+                && execute == null
+                && mojo == null
+                && getAfterAnnotations().isEmpty());
     }
 
     public boolean isV4Api() {
@@ -161,6 +182,7 @@ public class MojoAnnotatedClass {
         sb.append(", parentClassName='").append(parentClassName).append('\'');
         sb.append(", mojo=").append(mojo);
         sb.append(", execute=").append(execute);
+        sb.append(", afterAnnotations=").append(afterAnnotations);
         sb.append(", parameters=").append(parameters);
         sb.append(", components=").append(components);
         sb.append(", v4api=").append(v4Api);

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/MojoAnnotationsScanner.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/MojoAnnotationsScanner.java
@@ -44,7 +44,9 @@ public interface MojoAnnotationsScanner {
             Execute.class.getName(),
             Deprecated.class.getName(),
             V4_API_ANNOTATIONS_PACKAGE + ".Mojo",
-            V4_API_ANNOTATIONS_PACKAGE + ".Execute");
+            V4_API_ANNOTATIONS_PACKAGE + ".Execute",
+            V4_API_ANNOTATIONS_PACKAGE + ".After",
+            V4_API_ANNOTATIONS_PACKAGE + ".Afters");
 
     List<String> FIELD_LEVEL_ANNOTATIONS = Arrays.asList(
             Parameter.class.getName(),

--- a/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/visitors/MojoAnnotationVisitor.java
+++ b/maven-plugin-tools-annotations/src/main/java/org/apache/maven/tools/plugin/extractor/annotations/scanner/visitors/MojoAnnotationVisitor.java
@@ -18,11 +18,15 @@
  */
 package org.apache.maven.tools.plugin.extractor.annotations.scanner.visitors;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 /**
  * Visitor for annotations.
@@ -34,6 +38,10 @@ public class MojoAnnotationVisitor extends AnnotationVisitor {
     private String annotationClassName;
 
     private Map<String, Object> annotationValues = new HashMap<>();
+
+    private List<MojoAnnotationVisitor> nestedAnnotationVisitors;
+
+    private Map<String, MojoAnnotationVisitor> arrayVisitors;
 
     MojoAnnotationVisitor(String annotationClassName) {
         super(Opcodes.ASM9);
@@ -56,11 +64,44 @@ public class MojoAnnotationVisitor extends AnnotationVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(String name, String desc) {
-        return new MojoAnnotationVisitor(this.annotationClassName);
+        String className = desc != null ? Type.getType(desc).getClassName() : this.annotationClassName;
+        MojoAnnotationVisitor nested = new MojoAnnotationVisitor(className);
+        if (nestedAnnotationVisitors == null) {
+            nestedAnnotationVisitors = new ArrayList<>();
+        }
+        nestedAnnotationVisitors.add(nested);
+        return nested;
     }
 
     @Override
-    public AnnotationVisitor visitArray(String s) {
-        return new MojoAnnotationVisitor(this.annotationClassName);
+    public AnnotationVisitor visitArray(String name) {
+        MojoAnnotationVisitor arrayVisitor = new MojoAnnotationVisitor(this.annotationClassName);
+        if (this.arrayVisitors == null) {
+            this.arrayVisitors = new HashMap<>();
+        }
+        this.arrayVisitors.put(name, arrayVisitor);
+        return arrayVisitor;
+    }
+
+    /**
+     * Returns the sub-visitor created by {@link #visitArray(String)} for the given array attribute.
+     * The sub-visitor's {@link #getNestedAnnotationVisitors()} contains the annotation elements.
+     *
+     * @param name the array attribute name
+     * @return the array sub-visitor, or {@code null} if not visited
+     */
+    public MojoAnnotationVisitor getArrayVisitor(String name) {
+        return arrayVisitors != null ? arrayVisitors.get(name) : null;
+    }
+
+    /**
+     * Returns the nested annotation visitors collected by {@link #visitAnnotation(String, String)}
+     * and by array sub-visitors.  Used to extract elements from repeatable annotation containers
+     * such as {@code @Afters}.
+     *
+     * @return list of nested annotation visitors, never {@code null}
+     */
+    public List<MojoAnnotationVisitor> getNestedAnnotationVisitors() {
+        return nestedAnnotationVisitors != null ? nestedAnnotationVisitors : Collections.emptyList();
     }
 }

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/ExtendedMojoDescriptor.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/ExtendedMojoDescriptor.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.tools.plugin;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
@@ -31,6 +34,7 @@ import org.apache.maven.plugin.descriptor.Parameter;
 public class ExtendedMojoDescriptor extends MojoDescriptor {
     private final boolean containsXhtmlTextValues;
     private boolean v4Api;
+    private List<AfterLink> afterLinks;
 
     public ExtendedMojoDescriptor() {
         this(false);
@@ -61,6 +65,66 @@ public class ExtendedMojoDescriptor extends MojoDescriptor {
 
     public void setV4Api(boolean v4Api) {
         this.v4Api = v4Api;
+    }
+
+    /**
+     * Returns the after-links declared via {@code @After} annotations.
+     *
+     * @return unmodifiable list of after-links, never {@code null}
+     * @since 4.0.0
+     */
+    public List<AfterLink> getAfterLinks() {
+        return afterLinks != null ? Collections.unmodifiableList(afterLinks) : Collections.emptyList();
+    }
+
+    /**
+     * Adds an after-link.
+     *
+     * @param afterLink the after-link to add
+     * @since 4.0.0
+     */
+    public void addAfterLink(AfterLink afterLink) {
+        if (this.afterLinks == null) {
+            this.afterLinks = new ArrayList<>();
+        }
+        this.afterLinks.add(afterLink);
+    }
+
+    /**
+     * Holds after-link data from the {@code @After} annotation.
+     * <p>
+     * Mirrors the {@code org.apache.maven.api.plugin.descriptor.AfterLink} model class
+     * from the Maven 4 API without introducing a compile-time dependency on it.
+     *
+     * @since 4.0.0
+     */
+    public static class AfterLink {
+        private final String phase;
+        private final String type;
+        private final String scope;
+
+        public AfterLink(String phase, String type, String scope) {
+            this.phase = phase;
+            this.type = type;
+            this.scope = scope;
+        }
+
+        public String getPhase() {
+            return phase;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getScope() {
+            return scope;
+        }
+
+        @Override
+        public String toString() {
+            return "AfterLink{phase='" + phase + "', type='" + type + "', scope='" + scope + "'}";
+        }
     }
 
     @Override

--- a/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
+++ b/maven-plugin-tools-generators/src/main/java/org/apache/maven/tools/plugin/generator/PluginDescriptorFilesGenerator.java
@@ -333,6 +333,32 @@ public class PluginDescriptorFilesGenerator implements Generator {
         }
 
         // ----------------------------------------------------------------------
+        // After links (v4 API only)
+        // ----------------------------------------------------------------------
+
+        if (isV4 && mojoDescriptor instanceof ExtendedMojoDescriptor) {
+            List<ExtendedMojoDescriptor.AfterLink> afterLinks =
+                    ((ExtendedMojoDescriptor) mojoDescriptor).getAfterLinks();
+            if (!afterLinks.isEmpty()) {
+                w.startElement("afterLinks");
+                for (ExtendedMojoDescriptor.AfterLink afterLink : afterLinks) {
+                    w.startElement("afterLink");
+                    if (afterLink.getPhase() != null) {
+                        GeneratorUtils.element(w, "phase", afterLink.getPhase());
+                    }
+                    if (afterLink.getType() != null) {
+                        GeneratorUtils.element(w, "type", afterLink.getType());
+                    }
+                    if (afterLink.getScope() != null) {
+                        GeneratorUtils.element(w, "scope", afterLink.getScope());
+                    }
+                    w.endElement(); // afterLink
+                }
+                w.endElement(); // afterLinks
+            }
+        }
+
+        // ----------------------------------------------------------------------
         //
         // ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Register `@After` / `@Afters` (v4 API) in `CLASS_LEVEL_ANNOTATIONS` so the ASM scanner picks them up
- Add `AfterAnnotationContent` datamodel class and `List<AfterAnnotationContent>` field on `MojoAnnotatedClass`
- Enhance `MojoAnnotationVisitor` to track nested annotation visitors (needed to unpack the `@Afters` repeatable container)
- Process single `@After` and `@Afters` container in `DefaultMojoAnnotationsScanner.analyzeVisitors()`
- Walk the class hierarchy collecting `@After` annotations and map them to `ExtendedMojoDescriptor.AfterLink` in `JavaAnnotationsMojoDescriptorExtractor.toMojoDescriptors()`
- Emit `<afterLinks>/<afterLink>` elements in the v4 plugin descriptor via `PluginDescriptorFilesGenerator`

Complements https://github.com/apache/maven/pull/12535 which adds the model (`AfterLink` in `plugin.mdo`), runtime processing (`BuildPlanExecutor.applyAfterLinks`), `@Repeatable` support on `@After`, and an IT that currently hand-crafts the descriptor because the scanner did not exist yet.

## Test plan

- [x] All existing tests pass (28 tests, 0 failures)
- [x] Full project build succeeds
- [ ] Verify with the IT from apache/maven#12535 that the generated descriptor matches the hand-crafted one

🤖 Generated with [Claude Code](https://claude.com/claude-code)