### PR TITLE
Add validator for component requirements in generated plugin descriptor

### DIFF
--- a/maven-plugin-plugin/pom.xml
+++ b/maven-plugin-plugin/pom.xml
@@ -166,6 +166,11 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- needed for it tests -->
     <dependency>

--- a/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
+++ b/maven-plugin-plugin/src/it/java-basic-annotations/verify.groovy
@@ -194,4 +194,10 @@ assert mojo.deprecated.text() == 'No reason given'
 parameter = mojo.parameters.parameter.findAll{ it.name.text() == "param" }[0]
 assert parameter.deprecated.text() == 'No reason given'
 
-return true;
+def buildLog = new File(basedir, "build.log").text
+
+assert buildLog.contains('[WARNING] Mojo mplugin-396 uses Plexus Component requirements (@Component annotation) for fields: [projectHelper]')
+assert buildLog.contains('[WARNING] Mojo minimal uses Plexus Component requirements (@Component annotation) for fields: [projectHelper]')
+assert buildLog.contains('[WARNING] Mojo first uses Plexus Component requirements (@Component annotation) for fields: [mojo, plugin, project, projectHelper, session, settings]')
+assert buildLog.contains('[WARNING] Mojo maximal uses Plexus Component requirements (@Component annotation) for fields: [projectHelper]')
+assert buildLog.contains('[WARNING] Use JSR 330 annotations to inject dependencies instead.')

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/DescriptorGeneratorMojo.java
@@ -391,6 +391,9 @@ public class DescriptorGeneratorMojo extends AbstractGeneratorMojo {
 
             outputDirectory.mkdirs();
 
+            ValidateComponentRequirement validateComponentRequirement = new ValidateComponentRequirement();
+            validateComponentRequirement.validate(request.getPluginDescriptor(), getLog());
+
             PluginDescriptorFilesGenerator pluginDescriptorGenerator = new PluginDescriptorFilesGenerator();
             pluginDescriptorGenerator.execute(outputDirectory, request);
 

--- a/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/ValidateComponentRequirement.java
+++ b/maven-plugin-plugin/src/main/java/org/apache/maven/plugin/plugin/ValidateComponentRequirement.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+
+/**
+ * Validate if Mojo has a component requirement - uses a {@code @Component}
+ */
+class ValidateComponentRequirement {
+
+    public void validate(PluginDescriptor pluginDescriptor, Log logger) {
+
+        if (pluginDescriptor == null || pluginDescriptor.getMojos() == null) {
+            return;
+        }
+
+        boolean hasComponentRequirement = false;
+
+        for (MojoDescriptor mojo : pluginDescriptor.getMojos()) {
+
+            if (!"java".equalsIgnoreCase(mojo.getLanguage())) {
+                // only check java mojos
+                continue;
+            }
+
+            List<String> fieldsWithRequirements = getFieldsWithRequirements(mojo);
+            if (!fieldsWithRequirements.isEmpty()) {
+                hasComponentRequirement = true;
+                logger.warn(String.format(
+                        "Mojo %s uses Plexus Component requirements (@Component annotation) for fields: %s",
+                        mojo.getGoal(), fieldsWithRequirements));
+            }
+        }
+
+        if (hasComponentRequirement) {
+            logger.warn("Use JSR 330 annotations to inject dependencies instead.");
+        }
+    }
+
+    private List<String> getFieldsWithRequirements(MojoDescriptor mojo) {
+        List<String> list = new ArrayList<>();
+        // we map @Componetnt annotation to Mojo parameter with requirement
+        Optional.ofNullable(mojo.getParameters())
+                .map(Collection::stream)
+                .orElseGet(Stream::empty)
+                .filter(parameter -> parameter.getRequirement() != null)
+                .map(Parameter::getName)
+                .forEach(list::add);
+
+        // check also the requirements field
+        Optional.ofNullable(mojo.getRequirements())
+                .map(Collection::stream)
+                .orElseGet(Stream::empty)
+                .map(ComponentRequirement::getFieldName)
+                .forEach(list::add);
+        return list;
+    }
+}

--- a/maven-plugin-plugin/src/test/java/org/apache/maven/plugin/plugin/ValidateComponentRequirementTest.java
+++ b/maven-plugin-plugin/src/test/java/org/apache/maven/plugin/plugin/ValidateComponentRequirementTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.plugin;
+
+import java.util.Collections;
+
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.descriptor.Requirement;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class ValidateComponentRequirementTest {
+
+    @Test
+    void warnsForJavaMojoUsingComponentRequirements() throws Exception {
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.addMojo(aJavaMojoWithRequirement("test-goal", "componentField"));
+        Log logger = mock(Log.class);
+
+        new ValidateComponentRequirement().validate(pluginDescriptor, logger);
+
+        InOrder inOrder = inOrder(logger);
+        inOrder.verify(logger)
+                .warn("Mojo test-goal uses Plexus Component requirements (@Component annotation) for fields: "
+                        + "[componentField]");
+        inOrder.verify(logger).warn("Use JSR 330 annotations to inject dependencies instead.");
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void ignoresNonJavaMojo() throws Exception {
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.addMojo(aNonJavaMojoWithRequirement("test-goal", "componentField"));
+        Log logger = mock(Log.class);
+
+        new ValidateComponentRequirement().validate(pluginDescriptor, logger);
+
+        verifyNoInteractions(logger);
+    }
+
+    @Test
+    void ignoresJavaMojoWithoutRequirement() throws Exception {
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.addMojo(aJavaMojoWithoutRequirement("test-goal", "regularField"));
+        Log logger = mock(Log.class);
+
+        new ValidateComponentRequirement().validate(pluginDescriptor, logger);
+
+        verifyNoInteractions(logger);
+    }
+
+    private static MojoDescriptor aJavaMojoWithRequirement(String goal, String parameterName) throws Exception {
+        MojoDescriptor mojo = new MojoDescriptor();
+        mojo.setGoal(goal);
+        mojo.setLanguage("java");
+        mojo.setParameters(Collections.singletonList(aRequiredParameter(parameterName)));
+        return mojo;
+    }
+
+    private static MojoDescriptor aNonJavaMojoWithRequirement(String goal, String parameterName) throws Exception {
+        MojoDescriptor mojo = aJavaMojoWithRequirement(goal, parameterName);
+        mojo.setLanguage("bsh");
+        return mojo;
+    }
+
+    private static MojoDescriptor aJavaMojoWithoutRequirement(String goal, String parameterName) throws Exception {
+        MojoDescriptor mojo = new MojoDescriptor();
+        mojo.setGoal(goal);
+        mojo.setLanguage("java");
+        mojo.setParameters(Collections.singletonList(aParameterWithoutRequirement(parameterName)));
+        return mojo;
+    }
+
+    private static Parameter aRequiredParameter(String name) {
+        Parameter parameter = new Parameter();
+        parameter.setName(name);
+        parameter.setRequirement(new Requirement("org.example.Component", "default"));
+        return parameter;
+    }
+
+    private static Parameter aParameterWithoutRequirement(String name) {
+        Parameter parameter = new Parameter();
+        parameter.setName(name);
+        return parameter;
+    }
+}


### PR DESCRIPTION
### What changed
- Added `ValidateComponentRequirement` to scan generated `PluginDescriptor` mojos for Plexus component requirements (`@Component`-mapped requirements).
- Extended integration test verification (`java-basic-annotations/verify.groovy`) to assert the expected warning messages in `build.log`.

### Why
- `@Component` usage in mojos is deprecated, but generation currently gives no visible signal when `<requirement>` entries are produced.
- A warning at descriptor generation time helps plugin authors migrate toward JSR 330 injection and avoid hidden legacy patterns.

Fixes #1138

