### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-enabled: true  # build by Maven 3.x and 4.x
+      maven4-version: '4.0.0-rc-6' # the same as used in project
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
   <properties>
     <javaVersion>8</javaVersion>
     <pluginTestingHarnessVersion>3.5.1</pluginTestingHarnessVersion>
-    <maven4Version>4.0.0-rc-4</maven4Version>
+    <maven4Version>4.0.0-rc-6</maven4Version>
     <maven3Version>3.9.16</maven3Version>
     <resolverVersion>1.9.25</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>


### PR DESCRIPTION
4.0.0-rc-6 is released. This moves the Maven 4 version property to it and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

Verified: green on the fork before opening (`Verify` workflow, full matrix).
