### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/maven-plugin-annotations/src/site/markdown/index.md.vm
+++ b/maven-plugin-annotations/src/site/markdown/index.md.vm
@@ -1,3 +1,10 @@
+---
+title: About ${project.name}
+author: 
+  - Hervé Boutemy
+date: 2012-06-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-plugin/src/site/markdown/examples/generate-descriptor.md.vm
+++ b/maven-plugin-plugin/src/site/markdown/examples/generate-descriptor.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring Generation of Plugin Descriptor
+author: 
+  - Maria Odea Ching
+date: 2008-02-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-plugin/src/site/markdown/examples/generate-help.md.vm
+++ b/maven-plugin-plugin/src/site/markdown/examples/generate-help.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring Generation of Help Mojo
+author: 
+  - Vincent Siveton
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-plugin/src/site/markdown/examples/using-annotations.md.vm
+++ b/maven-plugin-plugin/src/site/markdown/examples/using-annotations.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using Plugin Tools Java5 Annotations
+author: 
+  - Olivier Lamy
+date: 2012-05-14
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-plugin/src/site/markdown/index.md
+++ b/maven-plugin-plugin/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Maria Odea Ching
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-plugin/src/site/markdown/usage.md
+++ b/maven-plugin-plugin/src/site/markdown/usage.md
@@ -1,3 +1,11 @@
+---
+title: Usage
+author: 
+  - Maria Odea Ching
+  - Vincent Siveton
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-report-plugin/src/site/markdown/examples/generate-report.md.vm
+++ b/maven-plugin-report-plugin/src/site/markdown/examples/generate-report.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring Generation of Documentation Reports
+author: 
+  - Vincent Siveton
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-report-plugin/src/site/markdown/index.md
+++ b/maven-plugin-report-plugin/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Maria Odea Ching
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-report-plugin/src/site/markdown/usage.md
+++ b/maven-plugin-report-plugin/src/site/markdown/usage.md
@@ -1,3 +1,11 @@
+---
+title: Usage
+author: 
+  - Maria Odea Ching
+  - Vincent Siveton
+date: 2008-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-tools-annotations/src/site/markdown/index.md
+++ b/maven-plugin-tools-annotations/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Hervé Boutemy
+date: 2012-05-12
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-plugin-tools-api/src/site/markdown/index.md
+++ b/maven-plugin-tools-api/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Vincent Siveton
+date: 2012-05-14
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.