### PR TITLE
Stop depending on Wagon for nonProxyHosts matching

### DIFF
--- a/maven-plugin-tools-api/pom.xml
+++ b/maven-plugin-tools-api/pom.xml
@@ -93,12 +93,6 @@
       <artifactId>httpcore</artifactId>
       <version>4.4.16</version>
     </dependency>
-    <!-- wagon for proxy related classes -->
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-provider-api</artifactId>
-      <version>3.5.3</version>
-    </dependency>
     <!-- for parsing java/javadoc versions -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocSite.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocSite.java
@@ -68,8 +68,6 @@ import org.apache.http.message.BasicHeader;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.tools.plugin.javadoc.FullyQualifiedJavadocReference.MemberType;
-import org.apache.maven.wagon.proxy.ProxyInfo;
-import org.apache.maven.wagon.proxy.ProxyUtils;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -508,11 +506,8 @@ class JavadocSite {
         if (settings != null && settings.getActiveProxy() != null) {
             Proxy activeProxy = settings.getActiveProxy();
 
-            ProxyInfo proxyInfo = new ProxyInfo();
-            proxyInfo.setNonProxyHosts(activeProxy.getNonProxyHosts());
-
             if (StringUtils.isNotEmpty(activeProxy.getHost())
-                    && (url == null || !ProxyUtils.validateNonProxyHosts(proxyInfo, url.getHost()))) {
+                    && (url == null || !isNonProxyHost(activeProxy.getNonProxyHosts(), url.getHost()))) {
                 HttpHost proxy = new HttpHost(activeProxy.getHost(), activeProxy.getPort());
                 builder.setProxy(proxy);
 
@@ -596,5 +591,24 @@ class JavadocSite {
      */
     public static boolean isNotEmpty(final Collection<?> collection) {
         return collection != null && !collection.isEmpty();
+    }
+
+    /**
+     * Whether a host is covered by a <code>nonProxyHosts</code> setting, and so should be reached directly
+     * rather than through the proxy. The setting is a <code>|</code>-separated list of patterns in which
+     * <code>*</code> stands for any run of characters, as in a Maven <code>settings.xml</code>.
+     */
+    static boolean isNonProxyHost(String nonProxyHosts, String targetHost) {
+        if (nonProxyHosts == null) {
+            return false;
+        }
+
+        String host = targetHost == null ? "" : targetHost;
+        for (String pattern : nonProxyHosts.split("\\|")) {
+            if (host.matches(pattern.replace(".", "\\.").replace("*", ".*"))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
@@ -35,7 +35,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -164,5 +166,31 @@ class JavadocSiteTest {
         } catch (IOException e) {
             fail("Could not find URL " + url, e);
         }
+    }
+
+    @Test
+    void nonProxyHostsMatchesAnExactHost() {
+        assertTrue(JavadocSite.isNonProxyHost("internal.example.com", "internal.example.com"));
+        assertFalse(JavadocSite.isNonProxyHost("internal.example.com", "example.com"));
+    }
+
+    @Test
+    void nonProxyHostsTreatsStarAsAWildcardAndDotAsALiteral() {
+        assertTrue(JavadocSite.isNonProxyHost("*.example.com", "docs.example.com"));
+        // the dot is escaped, so it must not match an arbitrary character
+        assertFalse(JavadocSite.isNonProxyHost("*.example.com", "docsXexample.com"));
+    }
+
+    @Test
+    void nonProxyHostsSplitsOnPipe() {
+        assertTrue(JavadocSite.isNonProxyHost("localhost|*.example.com", "docs.example.com"));
+        assertTrue(JavadocSite.isNonProxyHost("localhost|*.example.com", "localhost"));
+        assertFalse(JavadocSite.isNonProxyHost("localhost|*.example.com", "example.org"));
+    }
+
+    @Test
+    void nonProxyHostsToleratesNulls() {
+        assertFalse(JavadocSite.isNonProxyHost(null, "example.com"));
+        assertFalse(JavadocSite.isNonProxyHost("*.example.com", null));
     }
 }


### PR DESCRIPTION
`maven-plugin-tools-api` had a compile dependency on `wagon-provider-api` for two classes. Its own comment said what for:

```xml
<!-- wagon for proxy related classes -->
```

The entire use was building a `ProxyInfo` as a carrier for one string and passing it to `ProxyUtils.validateNonProxyHosts`:

```java
ProxyInfo proxyInfo = new ProxyInfo();
proxyInfo.setNonProxyHosts(activeProxy.getNonProxyHosts());

if (StringUtils.isNotEmpty(activeProxy.getHost())
        && (url == null || !ProxyUtils.validateNonProxyHosts(proxyInfo, url.getHost()))) {
```

The matching is a handful of lines with nothing Maven-specific in it — split on `|`, treat `*` as a wildcard and escape `.` — so it is done here and the dependency goes. Nothing else in plugin-tools touches Wagon.

Tests cover the four things worth pinning: an exact host, the wildcard with its escaped dot (so `*.example.com` must not match `docsXexample.com`), the pipe separator, and the null cases.

### Verification

`mvn -pl maven-plugin-tools-api test`: 44 tests before, 48 after — same 44 plus the 4 new ones, 0 failures throughout.

### Background

This came out of a survey of how Maven projects actually depend on Wagon. Three projects used `wagon-provider-api` purely as a utility library rather than as a transport. This is one; apache/maven-javadoc-plugin#1354 is the second.

The third, maven-jxr-plugin, is deliberately **not** being changed. It uses `Repository` to split a site URL into host and basedir, and Wagon's own source explains why that cannot move to `java.net.URI`:

> can't use URL class as is because it won't recognise our protocols

Site URLs are routinely `scp://` or `dav:https://`, so that parsing is genuinely Wagon's job.
