### PR TITLE
[maven-plugin-tools-3.x] Stop depending on Wagon for nonProxyHosts matching

### DIFF
--- a/maven-plugin-tools-api/pom.xml
+++ b/maven-plugin-tools-api/pom.xml
@@ -97,12 +97,6 @@
       <artifactId>httpcore</artifactId>
       <version>4.4.16</version>
     </dependency>
-    <!-- wagon for proxy related classes -->
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-provider-api</artifactId>
-      <version>3.5.3</version>
-    </dependency>
     <!-- for parsing java/javadoc versions -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocSite.java
+++ b/maven-plugin-tools-api/src/main/java/org/apache/maven/tools/plugin/javadoc/JavadocSite.java
@@ -68,8 +68,6 @@ import org.apache.http.message.BasicHeader;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.tools.plugin.javadoc.FullyQualifiedJavadocReference.MemberType;
-import org.apache.maven.wagon.proxy.ProxyInfo;
-import org.apache.maven.wagon.proxy.ProxyUtils;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -508,11 +506,8 @@ class JavadocSite {
         if (settings != null && settings.getActiveProxy() != null) {
             Proxy activeProxy = settings.getActiveProxy();
 
-            ProxyInfo proxyInfo = new ProxyInfo();
-            proxyInfo.setNonProxyHosts(activeProxy.getNonProxyHosts());
-
             if (StringUtils.isNotEmpty(activeProxy.getHost())
-                    && (url == null || !ProxyUtils.validateNonProxyHosts(proxyInfo, url.getHost()))) {
+                    && (url == null || !isNonProxyHost(activeProxy.getNonProxyHosts(), url.getHost()))) {
                 HttpHost proxy = new HttpHost(activeProxy.getHost(), activeProxy.getPort());
                 builder.setProxy(proxy);
 
@@ -596,5 +591,24 @@ class JavadocSite {
      */
     public static boolean isNotEmpty(final Collection<?> collection) {
         return collection != null && !collection.isEmpty();
+    }
+
+    /**
+     * Whether a host is covered by a <code>nonProxyHosts</code> setting, and so should be reached directly
+     * rather than through the proxy. The setting is a <code>|</code>-separated list of patterns in which
+     * <code>*</code> stands for any run of characters, as in a Maven <code>settings.xml</code>.
+     */
+    static boolean isNonProxyHost(String nonProxyHosts, String targetHost) {
+        if (nonProxyHosts == null) {
+            return false;
+        }
+
+        String host = targetHost == null ? "" : targetHost;
+        for (String pattern : nonProxyHosts.split("\\|")) {
+            if (host.matches(pattern.replace(".", "\\.").replace("*", ".*"))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteTest.java
@@ -35,7 +35,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -164,5 +166,31 @@ class JavadocSiteTest {
         } catch (IOException e) {
             fail("Could not find URL " + url, e);
         }
+    }
+
+    @Test
+    void nonProxyHostsMatchesAnExactHost() {
+        assertTrue(JavadocSite.isNonProxyHost("internal.example.com", "internal.example.com"));
+        assertFalse(JavadocSite.isNonProxyHost("internal.example.com", "example.com"));
+    }
+
+    @Test
+    void nonProxyHostsTreatsStarAsAWildcardAndDotAsALiteral() {
+        assertTrue(JavadocSite.isNonProxyHost("*.example.com", "docs.example.com"));
+        // the dot is escaped, so it must not match an arbitrary character
+        assertFalse(JavadocSite.isNonProxyHost("*.example.com", "docsXexample.com"));
+    }
+
+    @Test
+    void nonProxyHostsSplitsOnPipe() {
+        assertTrue(JavadocSite.isNonProxyHost("localhost|*.example.com", "docs.example.com"));
+        assertTrue(JavadocSite.isNonProxyHost("localhost|*.example.com", "localhost"));
+        assertFalse(JavadocSite.isNonProxyHost("localhost|*.example.com", "example.org"));
+    }
+
+    @Test
+    void nonProxyHostsToleratesNulls() {
+        assertFalse(JavadocSite.isNonProxyHost(null, "example.com"));
+        assertFalse(JavadocSite.isNonProxyHost("*.example.com", null));
     }
 }


### PR DESCRIPTION
Backport of #1151 to `maven-plugin-tools-3.x`. The cherry-pick was clean — `JavadocSite.java` is identical on the two branches.

`maven-plugin-tools-api` carries a compile dependency on `wagon-provider-api` for two classes, as its own comment says (`<!-- wagon for proxy related classes -->`). The whole use is building a `ProxyInfo` as a carrier for one string and passing it to `ProxyUtils.validateNonProxyHosts`. That matching is a handful of lines with nothing Maven-specific in it, so it is done in place and the dependency goes.

**Verified on this branch:** `mvn -pl maven-plugin-tools-api test` gives 48 tests, 0 failures — the 44 that were there plus the 4 new ones covering the wildcard, the escaped dot, the pipe separator and the null cases.

### Why on a maintenance branch at all

3.x is the line that ships, and it is still active — this branch had a commit yesterday. Removing a compile dependency does change the published POM of a future 3.x release, so this is a judgement call rather than an obvious bugfix, and I am happy for it to be declined if you would rather 3.x took fixes only. The equivalent change for `master` is #1151.
