### PR TITLE
MPLUGIN-421: Migrate legacy plugin Javadoc annotations

### DIFF
--- a/maven-plugin-report-plugin/src/it/fix-maven-since-3.x/javasample-maven-plugin/src/main/java/test/MyMojo.java
+++ b/maven-plugin-report-plugin/src/it/fix-maven-since-3.x/javasample-maven-plugin/src/main/java/test/MyMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
@@ -52,9 +53,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 public class MyMojo extends AbstractMojo {
     /**
      * Location of the file.
-     * @parameter property="project.build.directory"
-     * @required
      */
+    @Parameter(property = "project.build.directory", required = true)
     private File outputDirectory;
 
     public void execute() throws MojoExecutionException {


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Summary

Replace the remaining legacy `@parameter` and `@required` Javadoc tags in the plugin-report integration-test fixture with `@Parameter` metadata.

The rest of this fixture was migrated to `maven-plugin-annotations` in MPLUGIN-527, but the field-level tags were left behind. This change completes that conversion while preserving the required `project.build.directory` property expression. The fixture already has the annotation dependency, so no POM change is needed.

The generated descriptor contains:

```xml
<outputDirectory implementation="java.io.File">${project.build.directory}</outputDirectory>
```

This is an integration-test fixture cleanup and does not change production runtime behavior.

Related to https://github.com/apache/maven-plugin-tools/issues/718.

## Validation

The complete seven-module reactor and all integration tests passed on JDK 21 with both supported Maven lines:

```text
Apache Maven 3.9.16:       mvn -B -V -Prun-its verify
Apache Maven 4.0.0-rc-6:  mvn -B -V -Prun-its verify
```

For each run, all 12 `maven-plugin-report-plugin` integration tests passed, including `fix-maven-since-3.x`. The plugin-plugin matrix passed 28 fixtures and skipped only the fixture intended for the other Maven major version.
