### PR TITLE
Restore the common wording on the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -36,7 +36,7 @@ under the License.
       <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
       <subsection name="Files">
-        
+
         <p>This is the current stable version of <strong>${project.name}</strong>.</p>
 
         <table>
@@ -51,7 +51,7 @@ under the License.
           <tbody>
             <tr>
               <td>${project.name} ${project.version} (Source zip)</td>
-              <td><a href="[preferred]maven/plugin-tools/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
+              <td><a href="https://dlcdn.apache.org/maven/plugin-tools/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
               <td><a href="https://downloads.apache.org/maven/plugin-tools/${project.artifactId}-${project.version}-source-release.zip.sha512">${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
               <td><a href="https://downloads.apache.org/maven/plugin-tools/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
             </tr>
@@ -72,4 +72,3 @@ under the License.
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
The wording on this page had drifted from the text the rest of the Maven estate uses. This restores the shared form so the page is identical to its counterparts apart from the distribution area and the artifact name.

This is worth doing rather than cosmetic: in `apache/maven-shared-utils` the same kind of rewording had **silently dropped three hyperlinks** — the verification instructions, the KEYS file and the archive site — leaving them as plain prose. A link-set audit was run across every repository in this sweep to catch that class of loss.

No URL and no in-page anchor changes. `download.cgi` is left in place. The ASF licence header is left byte-for-byte as it was.

### Verification

Generated from a single canonical template that reproduces the existing form exactly; XML well-formedness checked and the link set compared before and after. Representative repositories were rendered before and after with a real site build. **This specific repository was not individually rendered** unless noted. Draft until CI is green.