### PR TITLE
Drop branch protection for the retired Doxia 1.x lines

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,8 +27,6 @@ github:
     - hacktoberfest
   protected_branches:
     master: { }
-    maven-plugin-tools-3.14.x: { }
-    maven-plugin-tools-3.7.x: { }
     maven-plugin-tools-3.x: { }
   pull_requests:
     del_branch_on_merge: true


### PR DESCRIPTION
Prerequisite for retiring `maven-plugin-tools-3.14.x` and `maven-plugin-tools-3.7.x`; see apache/maven-doxia#1079 for the containment evidence
and what the retirement costs. Nothing else in the file changes.

*This change was created with AI assistance.*
