### PR TITLE
Run the site ITs against the parent's site plugin version

### DIFF
--- a/maven-plugin-report-plugin/pom.xml
+++ b/maven-plugin-report-plugin/pom.xml
@@ -248,7 +248,7 @@
               <settingsFile>src/it/settings.xml</settingsFile>
               <streamLogsOnFailures>true</streamLogsOnFailures>
               <filterProperties>
-                <sitePluginVersion>3.20.0</sitePluginVersion>
+                <sitePluginVersion>${version.maven-site-plugin}</sitePluginVersion>
                 <projectInfoReportsPlugin>3.7.0</projectInfoReportsPlugin>
               </filterProperties>
               <properties>


### PR DESCRIPTION
`sitePluginVersion` is the filter token the integration tests substitute into their own POMs, so this
changes which site plugin the ITs exercise, not how this project's site is built. Every other
repository in the estate already takes it from `${version.maven-site-plugin}`; three still carry a
literal 3.20.0, which predates the anchor-generation change in 3.21.0/3.22.0.

The ASF parent currently resolves that to 3.22.0. If an IT asserts on generated anchors it will fail
here, and that failure is the point of the change.

*This change was created with AI assistance.*
