### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginReport.java
+++ b/maven-plugin-report-plugin/src/main/java/org/apache/maven/plugin/plugin/report/PluginReport.java
@@ -265,10 +265,19 @@ public class PluginReport extends AbstractMavenReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public String getOutputName() {
+    public String getOutputPath() {
         return "plugin-info";
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the pattern in the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and already used by maven-javadoc-plugin and maven-pmd-plugin: `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

No behaviour change — `plugin-info` is the same string. The `DummyReport` fixtures under `src/it` are left alone.

Verified: `mvn test -pl maven-plugin-report-plugin` → 3 tests, 0 failures.

*This change was created with AI assistance.*
