### PR TITLE
Skip JavadocSiteIT when the remote javadoc site is unreachable

### DIFF
--- a/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteIT.java
+++ b/maven-plugin-tools-api/src/test/java/org/apache/maven/tools/plugin/javadoc/JavadocSiteIT.java
@@ -18,15 +18,26 @@
  */
 package org.apache.maven.tools.plugin.javadoc;
 
+import javax.net.ssl.SSLException;
+
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.stream.Stream;
 
 import org.apache.maven.settings.Settings;
 import org.apache.maven.tools.plugin.javadoc.FullyQualifiedJavadocReference.MemberType;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assumptions.abort;
+
+@ExtendWith(JavadocSiteIT.AbortWhenSiteUnreachable.class)
 class JavadocSiteIT {
 
     static Stream<Arguments> javadocBaseUrls() {
@@ -74,5 +85,26 @@ class JavadocSiteIT {
     void clazz(URI javadocBaseUrl) throws Exception {
         JavadocSite site = new JavadocSite(javadocBaseUrl, (Settings) null);
         JavadocSiteTest.assertUrlValid(site.createLink("java.lang", "String"));
+    }
+
+    /**
+     * Turns a failure to reach the remote javadoc site into a skipped test, so that a slow or blocked network does not
+     * make the build red. A wrong link still fails: {@link JavadocSite#getReader(java.net.URL,
+     * org.apache.maven.settings.Settings)} reports every non-200 as {@code FileNotFoundException}, which is not
+     * handled here.
+     */
+    static final class AbortWhenSiteUnreachable implements TestExecutionExceptionHandler {
+        @Override
+        public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+            for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+                if (cause instanceof SocketTimeoutException
+                        || cause instanceof SocketException
+                        || cause instanceof UnknownHostException
+                        || cause instanceof SSLException) {
+                    abort("Remote javadoc site is unreachable: " + cause);
+                }
+            }
+            throw throwable;
+        }
     }
 }


### PR DESCRIPTION
`JavadocSiteIT` fetches Oracle's live javadoc for JDK 8/11/17, so a slow or blocked network turns the build red for reasons that say nothing about the code — most recently a `SocketTimeoutException` on a macOS runner, after `JavadocSite.getReader` had already retried once.

A `TestExecutionExceptionHandler` on the class now walks the cause chain and skips the test when the failure is transport-level: `SocketTimeoutException`, `SocketException` (which covers HttpClient's `HttpHostConnectException`), `UnknownHostException`, `SSLException`. Everything else is rethrown unchanged.

The distinction matters and is the reason this is not a blanket `catch (IOException)`: `getReader` reports every non-200 as `FileNotFoundException`, so "Oracle moved the page or changed the anchor scheme" — the thing this IT exists to catch — still fails the build.

The handler sits around the whole test rather than inside `assertUrlValid`, because the site is fetched while the link is being built: with an unreachable host, the failure comes out of `createLink`, before any assertion runs.

Verified, all three cases:

| Base URL | Result |
|---|---|
| the real Oracle URLs | `Tests run: 15, Failures: 0, Errors: 0, Skipped: 0` |
| `http://127.0.0.1:1/docs/api/` (refused) | `Tests run: 5, Skipped: 5`, BUILD SUCCESS |
| `.../17/docs/api-does-not-exist/` (reachable, wrong path) | `Tests run: 5, Errors: 5`, BUILD FAILURE |

Offline coverage is unaffected: `JavadocSiteTest` already runs the same assertions against the checked-in javadoc fixtures for JDK 8/11/17/21 over `file:` URLs.

*This change was created with AI assistance.*
