### PR TITLE
Bump version to 3.17.0-SNAPSHOT

### DIFF
--- a/maven-plugin-annotations/pom.xml
+++ b/maven-plugin-annotations/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-annotations</artifactId>

--- a/maven-plugin-plugin/pom.xml
+++ b/maven-plugin-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.maven.plugins</groupId>

--- a/maven-plugin-report-plugin/pom.xml
+++ b/maven-plugin-report-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.maven.plugins</groupId>

--- a/maven-plugin-tools-annotations/pom.xml
+++ b/maven-plugin-tools-annotations/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-annotations</artifactId>

--- a/maven-plugin-tools-api/pom.xml
+++ b/maven-plugin-tools-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-api</artifactId>

--- a/maven-plugin-tools-generators/pom.xml
+++ b/maven-plugin-tools-generators/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-generators</artifactId>

--- a/maven-plugin-tools-java/pom.xml
+++ b/maven-plugin-tools-java/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-java</artifactId>

--- a/maven-script/maven-plugin-tools-ant/pom.xml
+++ b/maven-script/maven-plugin-tools-ant/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-script</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-ant</artifactId>

--- a/maven-script/maven-plugin-tools-beanshell/pom.xml
+++ b/maven-script/maven-plugin-tools-beanshell/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-script</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-beanshell</artifactId>

--- a/maven-script/maven-plugin-tools-model/pom.xml
+++ b/maven-script/maven-plugin-tools-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-script</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-plugin-tools-model</artifactId>

--- a/maven-script/maven-script-ant/pom.xml
+++ b/maven-script/maven-script-ant/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-script</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-script-ant</artifactId>

--- a/maven-script/maven-script-beanshell/pom.xml
+++ b/maven-script/maven-script-beanshell/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-script</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-script-beanshell</artifactId>

--- a/maven-script/pom.xml
+++ b/maven-script/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugin-tools</groupId>
     <artifactId>maven-plugin-tools</artifactId>
-    <version>3.16.1-SNAPSHOT</version>
+    <version>3.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-script</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.maven.plugin-tools</groupId>
   <artifactId>maven-plugin-tools</artifactId>
-  <version>3.16.1-SNAPSHOT</version>
+  <version>3.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Maven Plugin Tools</name>


### PR DESCRIPTION
The JavaParser-backend migration in #1193 swaps the QDox parser out from under the annotation-based mojo extractor, which reads as more than a patch-level change. Bumping the 3.x line's next development version accordingly, ahead of that PR, so it lands on 3.17.0-SNAPSHOT rather than 3.16.1-SNAPSHOT.

*This change was created with AI assistance.*